### PR TITLE
feat: Support sha256 string of password

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,5 +17,6 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-unused-vars': 'off',
+    'no-console': ['error', { allow: ['info', 'debug', 'warn', 'error'] }],
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lenne.tech/nest-server",
-  "version": "8.6.24",
+  "version": "8.6.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lenne.tech/nest-server",
-      "version": "8.6.24",
+      "version": "8.6.25",
       "license": "MIT",
       "dependencies": {
         "@apollo/gateway": "2.0.5",
@@ -28,7 +28,7 @@
         "graphql": "16.5.0",
         "graphql-subscriptions": "2.0.0",
         "graphql-upload": "15.0.2",
-        "js-sha256": "^0.9.0",
+        "js-sha256": "0.9.0",
         "json-to-graphql-query": "2.2.4",
         "light-my-request": "5.0.0",
         "lodash": "4.17.21",
@@ -4867,9 +4867,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.176",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.176.tgz",
-      "integrity": "sha512-92JdgyRlcNDwuy75MjuFSb3clt6DGJ2IXSpg0MCjKd3JV9eSmuUAIyWiGAp/EtT0z2D4rqbYqThQLV90maH3Zw==",
+      "version": "1.4.177",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.177.tgz",
+      "integrity": "sha512-FYPir3NSBEGexSZUEeht81oVhHfLFl6mhUKSkjHN/iB/TwEIt/WHQrqVGfTLN5gQxwJCQkIJBe05eOXjI7omgg==",
       "dev": true
     },
     "node_modules/emitter-listener": {
@@ -16458,9 +16458,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.176",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.176.tgz",
-      "integrity": "sha512-92JdgyRlcNDwuy75MjuFSb3clt6DGJ2IXSpg0MCjKd3JV9eSmuUAIyWiGAp/EtT0z2D4rqbYqThQLV90maH3Zw==",
+      "version": "1.4.177",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.177.tgz",
+      "integrity": "sha512-FYPir3NSBEGexSZUEeht81oVhHfLFl6mhUKSkjHN/iB/TwEIt/WHQrqVGfTLN5gQxwJCQkIJBe05eOXjI7omgg==",
       "dev": true
     },
     "emitter-listener": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "graphql": "16.5.0",
         "graphql-subscriptions": "2.0.0",
         "graphql-upload": "15.0.2",
+        "js-sha256": "^0.9.0",
         "json-to-graphql-query": "2.2.4",
         "light-my-request": "5.0.0",
         "lodash": "4.17.21",
@@ -8510,6 +8511,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -19214,6 +19220,11 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
       "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="
+    },
+    "js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "graphql": "16.5.0",
     "graphql-subscriptions": "2.0.0",
     "graphql-upload": "15.0.2",
+    "js-sha256": "0.9.0",
     "json-to-graphql-query": "2.2.4",
     "light-my-request": "5.0.0",
     "lodash": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lenne.tech/nest-server",
-  "version": "8.6.24",
+  "version": "8.6.25",
   "description": "Modern, fast, powerful Node.js web framework in TypeScript based on Nest with a GraphQL API and a connection to MongoDB (or other databases).",
   "keywords": [
     "node",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "docs:ci": "ts-node ./scripts/init-server.ts && npm run docs:boostrap",
     "format": "prettier --write 'src/**/*.ts'",
     "format:staged": "pretty-quick --staged",
-    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "lint": "eslint \"{src,tests}/**/*.ts\" --fix",
     "prestart:prod": "npm run build",
     "reinit": "rimraf package-lock.json && rimraf node_modules && npm cache clean --force && npm i && npm run test:e2e && npm run build",
     "reinit:force": "rimraf package-lock.json && rimraf node_modules && npm cache clean --force && npm i --force && npm run test:e2e",

--- a/src/config.env.ts
+++ b/src/config.env.ts
@@ -173,7 +173,7 @@ const config: { [env: string]: IServerOptions } = {
  */
 const env = process.env['NODE' + '_ENV'] || 'development';
 const envConfig = config[env] || config.development;
-console.log('Configured for: ' + envConfig.env + (env !== envConfig.env ? ' (requested: ' + env + ')' : ''));
+console.info('Configured for: ' + envConfig.env + (env !== envConfig.env ? ' (requested: ' + env + ')' : ''));
 
 /**
  * Export envConfig as default

--- a/src/core/common/decorators/restricted.decorator.ts
+++ b/src/core/common/decorators/restricted.decorator.ts
@@ -118,7 +118,14 @@ export const checkRestricted = (
 
       // Check roles
       if (roles.length) {
+        // Prevent access for everyone, including administrators
+        if (roles.includes(RoleEnum.S_NO_ONE)) {
+          return false;
+        }
+
+        // Check access rights
         if (
+          roles.includes(RoleEnum.S_EVERYONE) ||
           user?.hasRole?.(roles) ||
           (user?.id && roles.includes(RoleEnum.S_USER)) ||
           (roles.includes(RoleEnum.S_CREATOR) && getIncludedIds(config.dbObject?.createdBy, user))

--- a/src/core/common/decorators/restricted.decorator.ts
+++ b/src/core/common/decorators/restricted.decorator.ts
@@ -4,6 +4,7 @@ import { ProcessType } from '../enums/process-type.enum';
 import { RoleEnum } from '../enums/role.enum';
 import { getIncludedIds } from '../helpers/db.helper';
 import { RequireAtLeastOne } from '../types/required-at-least-one.type';
+import * as _ from 'lodash';
 
 /**
  * Restricted meta key
@@ -57,6 +58,7 @@ export const checkRestricted = (
   data: any,
   user: { id: any; hasRole: (roles: string[]) => boolean },
   options: {
+    checkObjectItself?: boolean;
     dbObject?: any;
     ignoreUndefined?: boolean;
     processType?: ProcessType;
@@ -66,6 +68,7 @@ export const checkRestricted = (
   processedObjects: any[] = []
 ) => {
   const config = {
+    checkObjectItself: false,
     ignoreUndefined: true,
     removeUndefinedFromResultArray: true,
     throwError: true,
@@ -95,102 +98,107 @@ export const checkRestricted = (
 
   // Check function
   const validateRestricted = (restricted) => {
-    let valid = true;
-    if (restricted?.length) {
-      valid = false;
+    // Check restrictions
+    if (!restricted?.length) {
+      return true;
+    }
 
-      // Get roles
-      const roles: string[] = [];
-      restricted.forEach((item) => {
-        if (typeof item === 'string') {
-          roles.push(item);
-        } else if (
-          item?.roles?.length &&
-          (config.processType && item.processType ? config.processType === item.processType : true)
-        ) {
-          if (Array.isArray(item.roles)) {
-            roles.push(...item.roles);
-          } else {
-            roles.push(item.roles);
-          }
-        }
-      });
+    let valid = false;
 
-      // Check roles
-      if (roles.length) {
-        // Prevent access for everyone, including administrators
-        if (roles.includes(RoleEnum.S_NO_ONE)) {
-          return false;
-        }
-
-        // Check access rights
-        if (
-          roles.includes(RoleEnum.S_EVERYONE) ||
-          user?.hasRole?.(roles) ||
-          (user?.id && roles.includes(RoleEnum.S_USER)) ||
-          (roles.includes(RoleEnum.S_CREATOR) && getIncludedIds(config.dbObject?.createdBy, user))
-        ) {
-          valid = true;
+    // Get roles
+    const roles: string[] = [];
+    restricted.forEach((item) => {
+      if (typeof item === 'string') {
+        roles.push(item);
+      } else if (
+        item?.roles?.length &&
+        (config.processType && item.processType ? config.processType === item.processType : true)
+      ) {
+        if (Array.isArray(item.roles)) {
+          roles.push(...item.roles);
+        } else {
+          roles.push(item.roles);
         }
       }
+    });
 
-      if (!valid) {
-        // Get groups
-        const groups = restricted.filter((item) => {
-          return (
-            typeof item === 'object' &&
-            // Check if object is valid
-            item.memberOf?.length &&
-            // Check if processType is specified and is valid for current process
-            (config.processType && item.processType ? config.processType === item.processType : true)
-          );
-        }) as { memberOf: string | string[] }[];
+    // Check roles
+    if (roles.length) {
+      // Prevent access for everyone, including administrators
+      if (roles.includes(RoleEnum.S_NO_ONE)) {
+        return false;
+      }
 
-        // Check groups
-        if (groups.length) {
-          // Get members from groups
-          const members = [];
-          for (const group of groups) {
-            let properties: string[] = group.memberOf as string[];
-            if (!Array.isArray(group.memberOf)) {
-              properties = [group.memberOf];
-            }
-            for (const property of properties) {
-              const items = config.dbObject?.[property];
-              if (items) {
-                if (Array.isArray(items)) {
-                  members.concat(items);
-                } else {
-                  members.push(items);
-                }
+      // Check access rights
+      if (
+        roles.includes(RoleEnum.S_EVERYONE) ||
+        user?.hasRole?.(roles) ||
+        (user?.id && roles.includes(RoleEnum.S_USER)) ||
+        (roles.includes(RoleEnum.S_CREATOR) && getIncludedIds(config.dbObject?.createdBy, user))
+      ) {
+        valid = true;
+      }
+    }
+
+    if (!valid) {
+      // Get groups
+      const groups = restricted.filter((item) => {
+        return (
+          typeof item === 'object' &&
+          // Check if object is valid
+          item.memberOf?.length &&
+          // Check if processType is specified and is valid for current process
+          (config.processType && item.processType ? config.processType === item.processType : true)
+        );
+      }) as { memberOf: string | string[] }[];
+
+      // Check groups
+      if (groups.length) {
+        // Get members from groups
+        const members = [];
+        for (const group of groups) {
+          let properties: string[] = group.memberOf as string[];
+          if (!Array.isArray(group.memberOf)) {
+            properties = [group.memberOf];
+          }
+          for (const property of properties) {
+            const items = config.dbObject?.[property];
+            if (items) {
+              if (Array.isArray(items)) {
+                members.concat(items);
+              } else {
+                members.push(items);
               }
             }
           }
-
-          // Check if user is a member
-          if (getIncludedIds(members, user)) {
-            valid = true;
-          }
         }
 
-        // Check if there are no limitations
-        if (!roles.length && !groups.length) {
+        // Check if user is a member
+        if (getIncludedIds(members, user)) {
           valid = true;
         }
       }
+
+      // Check if there are no limitations
+      if (!roles.length && !groups.length) {
+        valid = true;
+      }
     }
+
     return valid;
   };
 
   // Check object
-  const objectRestrictions = getRestricted(data.constructor);
-  const objectIsValid = validateRestricted(objectRestrictions);
-  if (!objectIsValid) {
-    // Throw error
-    if (config.throwError) {
-      throw new UnauthorizedException('The current user has no access rights for ' + data.constructor?.name);
+  const objectRestrictions = getRestricted(data.constructor) || [];
+  if (config.checkObjectItself) {
+    const objectIsValid = validateRestricted(objectRestrictions);
+    if (!objectIsValid) {
+      // Throw error
+      if (config.throwError) {
+        throw new UnauthorizedException('The current user has no access rights for ' + data.constructor?.name);
+      }
+      return null;
     }
-    return null;
   }
 
   // Check properties of object
@@ -201,8 +209,9 @@ export const checkRestricted = (
     }
 
     // Check restricted
-    const restricted = getRestricted(data, propertyKey);
-    const valid = validateRestricted(restricted);
+    const restricted = getRestricted(data, propertyKey) || [];
+    const concatenatedRestrictions = _.uniq(objectRestrictions.concat(restricted));
+    const valid = validateRestricted(concatenatedRestrictions);
 
     // Check rights
     if (valid) {
@@ -211,7 +220,11 @@ export const checkRestricted = (
     } else {
       // Throw error
       if (config.throwError) {
-        throw new UnauthorizedException('The current user has no access rights for ' + propertyKey);
+        throw new UnauthorizedException(
+          'The current user has no access rights for ' +
+            propertyKey +
+            (data.constructor?.name ? ' of ' + data.constructor.name : '')
+        );
       }
 
       // Remove property

--- a/src/core/common/enums/role.enum.ts
+++ b/src/core/common/enums/role.enum.ts
@@ -3,7 +3,7 @@
  *
  * There are two types of roles. The "normal" roles that can be defined as strings on the user in the `roles` property
  * and there are special system roles (with the prefix `S_`) that are defined by the current context e.g.
- * `S_USER` applies to all logged in users or `S_CREATOR` applies to the creator of a specific object.
+ * `S_USER` applies to all logged-in users or `S_CREATOR` applies to the creator of a specific object.
  * The special roles can only be used under certain situations (see below). The "normal" roles can be used anywhere
  * that involves checking the current user.
  *
@@ -23,17 +23,17 @@
  */
 export enum RoleEnum {
   // ===================================================================================================================
-  // Real roles (integrated into user.roles), which can be used via @Restricted for Model class and properties,
-  // via @Roles for Resolver class and methods and via ServiceOptions for Resolver methods.
+  // Real roles (integrated into user.roles), which can be used via @Restricted for Models (classes and properties),
+  // via @Roles for Resolvers (classes and methods) and via ServiceOptions for Resolver methods.
   // ===================================================================================================================
 
   // User must be an administrator (see roles of user)
   ADMIN = 'admin',
 
   // ===================================================================================================================
-  // Special system roles, which can be used via @Restricted for Model class and properties, via @Roles for Resolver
-  // class and methods and via ServiceOptions for Resolver methods. This roles should not be integrated into
-  // user.roles!
+  // Special system roles, which can be used via @Restricted for Models (classes and properties), via @Roles for
+  // Resolvers (classes and methods) and via ServiceOptions for Resolver methods. This roles should not be integrated
+  // into user.roles!
   // ===================================================================================================================
 
   // Everyone, including users who are not logged in, can access (see context user, e.g. @GraphQLUser)
@@ -46,8 +46,8 @@ export enum RoleEnum {
   S_USER = 's_user',
 
   // ===================================================================================================================
-  // Special system roles that check rights for DB objects and can be used via @Restricted for Model
-  // class and properties and via ServiceOptions for Resolver methods. These roles should not be integrated in
+  // Special system roles that check rights for DB objects and can be used via @Restricted for Models
+  // (classes and properties) and via ServiceOptions for Resolver methods. These roles should not be integrated in
   // user.roles!
   // ===================================================================================================================
 

--- a/src/core/common/enums/role.enum.ts
+++ b/src/core/common/enums/role.enum.ts
@@ -1,5 +1,19 @@
 /**
  * Enums for Resolver @Role and Model @Restricted decorator and for roles property in ServiceOptions
+ *
+ * Except for the role `S_NO_ONE` all roles extend the access. If for example the role `ADMIN` is specified for a class
+ * then the accesses to all methods / properties are limited to administrators. If then e.g. for a method of the class
+ * the role `S_USER` is specified, the method is accessible for all users (administrators & all users = all users). All
+ * other methods and properties of the class are still only accessible for administrators.
+ *
+ * The role `S_NO_ONE` is an exception to this behavior. If this role is specified, then no one can access the
+ * associated class or associated methods and properties no matter what other roles were specified for access.
+ * This role should be used thus only for classes, methods or characteristics, which are to be locked for a transition
+ * period but not deleted from the source code completely.
+ *
+ * The roles are divided into different scopes and can be used in `@Roles` or `@Restricted`. The scopes are specified
+ * and explained below.
+ *
  */
 export enum RoleEnum {
   // ===================================================================================================================
@@ -14,6 +28,12 @@ export enum RoleEnum {
   // Special system roles, which can be used via @Restricted for Models (properties), via @Roles for Resolvers (methods)
   // and via ServiceOptions for Resolver methods. This roles should not be integrated into user.roles!
   // ===================================================================================================================
+
+  // Everyone, including users who are not logged in, can access (see context user, e.g. @GraphQLUser)
+  S_EVERYONE = 's_everyone',
+
+  // No one has access, not even administrators
+  S_NO_ONE = 's_no_one',
 
   // User must be logged in (see context user, e.g. @GraphQLUser)
   S_USER = 's_user',

--- a/src/core/common/enums/role.enum.ts
+++ b/src/core/common/enums/role.enum.ts
@@ -1,6 +1,12 @@
 /**
  * Enums for Resolver @Role and Model @Restricted decorator and for roles property in ServiceOptions
  *
+ * There are two types of roles. The "normal" roles that can be defined as strings on the user in the `roles` property
+ * and there are special system roles (with the prefix `S_`) that are defined by the current context e.g.
+ * `S_USER` applies to all logged in users or `S_CREATOR` applies to the creator of a specific object.
+ * The special roles can only be used under certain situations (see below). The "normal" roles can be used anywhere
+ * that involves checking the current user.
+ *
  * Except for the role `S_NO_ONE` all roles extend the access. If for example the role `ADMIN` is specified for a class
  * then the accesses to all methods / properties are limited to administrators. If then e.g. for a method of the class
  * the role `S_USER` is specified, the method is accessible for all users (administrators & all users = all users). All
@@ -17,16 +23,17 @@
  */
 export enum RoleEnum {
   // ===================================================================================================================
-  // Real roles (integrated into user.roles), which can be used via @Restricted for Models (properties),
-  // via @Roles for Resolvers (methods) and via ServiceOptions for Resolver methods.
+  // Real roles (integrated into user.roles), which can be used via @Restricted for Model class and properties,
+  // via @Roles for Resolver class and methods and via ServiceOptions for Resolver methods.
   // ===================================================================================================================
 
   // User must be an administrator (see roles of user)
   ADMIN = 'admin',
 
   // ===================================================================================================================
-  // Special system roles, which can be used via @Restricted for Models (properties), via @Roles for Resolvers (methods)
-  // and via ServiceOptions for Resolver methods. This roles should not be integrated into user.roles!
+  // Special system roles, which can be used via @Restricted for Model class and properties, via @Roles for Resolver
+  // class and methods and via ServiceOptions for Resolver methods. This roles should not be integrated into
+  // user.roles!
   // ===================================================================================================================
 
   // Everyone, including users who are not logged in, can access (see context user, e.g. @GraphQLUser)
@@ -39,8 +46,9 @@ export enum RoleEnum {
   S_USER = 's_user',
 
   // ===================================================================================================================
-  // Special system roles that check rights for DB objects and can be used via @Restricted for Models (properties)
-  // and via ServiceOptions for Resolver methods. These roles should not be integrated in user.roles!
+  // Special system roles that check rights for DB objects and can be used via @Restricted for Model
+  // class and properties and via ServiceOptions for Resolver methods. These roles should not be integrated in
+  // user.roles!
   // ===================================================================================================================
 
   // User must be the creator of the processed object(s) (see createdBy property of object(s))

--- a/src/core/common/helpers/context.helper.ts
+++ b/src/core/common/helpers/context.helper.ts
@@ -30,14 +30,14 @@ export function getContextData(context: ExecutionContext): { currentUser: { [key
   try {
     ctx = GqlExecutionContext.create(context)?.getContext();
   } catch (e) {
-    // console.log(e);
+    // console.info(e);
   }
 
   let args: any;
   try {
     args = GqlExecutionContext.create(context)?.getArgs();
   } catch (e) {
-    // console.log(e);
+    // console.info(e);
   }
 
   // Get data

--- a/src/core/common/helpers/input.helper.ts
+++ b/src/core/common/helpers/input.helper.ts
@@ -232,7 +232,16 @@ export async function check(
       roles = [roles];
     }
     let valid = false;
+
+    // Prevent access for everyone, including administrators
+    if (roles.includes(RoleEnum.S_NO_ONE)) {
+      throw new UnauthorizedException('No access');
+    }
+
+    // Check access
     if (
+      // check if any user, including users who are not logged in, can access
+      roles.includes(RoleEnum.S_EVERYONE) ||
       // check if user is logged in
       (roles.includes(RoleEnum.S_USER) && user?.id) ||
       // check if the user has at least one of the required roles

--- a/src/core/common/helpers/input.helper.ts
+++ b/src/core/common/helpers/input.helper.ts
@@ -317,6 +317,14 @@ export function filterProperties<T = Record<string, any>>(
 }
 
 /**
+ * Get plain copy of object
+ * @param element
+ */
+export function getPlain(object: any) {
+  return JSON.parse(JSON.stringify(object));
+}
+
+/**
  * Check if parameter is an array
  */
 export function isArray(parameter: any, falseFunction: (...params) => any = errorFunction): boolean {

--- a/src/core/common/helpers/model.helper.ts
+++ b/src/core/common/helpers/model.helper.ts
@@ -164,7 +164,8 @@ export function maps<T = Record<string, any>>(
 export function mapClasses<T = Record<string, any>>(
   input: Record<string, any>,
   mapping: Record<string, new (...args: any[]) => any>,
-  target?: T
+  target?: T,
+  options?: { objectIdsToString?: boolean }
 ): T {
   // Check params
   if (!target) {
@@ -173,6 +174,12 @@ export function mapClasses<T = Record<string, any>>(
   if (!input || !mapping) {
     return target;
   }
+
+  // Get config
+  const config = {
+    objectIdsToString: true,
+    ...options,
+  };
 
   // Process input
   for (const [prop, mapTarget] of Object.entries(mapping)) {
@@ -187,7 +194,7 @@ export function mapClasses<T = Record<string, any>>(
           if (value instanceof targetClass) {
             arr.push(value);
           } else if (value instanceof Types.ObjectId) {
-            arr.push(value);
+            config.objectIdsToString ? arr.push(value.toHexString()) : arr.push(value);
           } else if (typeof value === 'object') {
             if (targetClass.map) {
               arr.push(targetClass.map(item));
@@ -203,7 +210,7 @@ export function mapClasses<T = Record<string, any>>(
 
       // Process ObjectId
       else if (value instanceof Types.ObjectId) {
-        target[prop] = value as any;
+        target[prop] = config.objectIdsToString ? value.toHexString() : value;
       }
 
       // Process object
@@ -240,7 +247,8 @@ export function mapClasses<T = Record<string, any>>(
 export async function mapClassesAsync<T = Record<string, any>>(
   input: Record<string, any>,
   mapping: Record<string, new (...args: any[]) => any>,
-  target?: T
+  target?: T,
+  options?: { objectIdsToString?: boolean }
 ): Promise<T> {
   // Check params
   if (!target) {
@@ -249,6 +257,12 @@ export async function mapClassesAsync<T = Record<string, any>>(
   if (!input || !mapping) {
     return target;
   }
+
+  // Get config
+  const config = {
+    objectIdsToString: true,
+    ...options,
+  };
 
   // Process input
   for (const [prop, mapTarget] of Object.entries(mapping)) {
@@ -263,7 +277,7 @@ export async function mapClassesAsync<T = Record<string, any>>(
           if (value instanceof targetClass) {
             arr.push(value);
           } else if (value instanceof Types.ObjectId) {
-            arr.push(value);
+            config.objectIdsToString ? arr.push(value.toHexString()) : arr.push(value);
           } else if (typeof value === 'object') {
             if (targetClass.map) {
               arr.push(await targetClass.map(item));
@@ -279,7 +293,7 @@ export async function mapClassesAsync<T = Record<string, any>>(
 
       // Process ObjectId
       else if (value instanceof Types.ObjectId) {
-        target[prop] = value as any;
+        target[prop] = config.objectIdsToString ? value.toHexString() : value;
       }
 
       // Process object

--- a/src/core/common/helpers/service.helper.ts
+++ b/src/core/common/helpers/service.helper.ts
@@ -3,6 +3,7 @@ import * as bcrypt from 'bcrypt';
 import { plainToInstance } from 'class-transformer';
 import { sha256 } from 'js-sha256';
 import * as _ from 'lodash';
+import { Types } from 'mongoose';
 import { RoleEnum } from '../enums/role.enum';
 import { PrepareInputOptions } from '../interfaces/prepare-input-options.interface';
 import { PrepareOutputOptions } from '../interfaces/prepare-output-options.interface';
@@ -163,6 +164,7 @@ export async function prepareOutput<T = { [key: string]: any; map: (...args: any
     [key: string]: any;
     clone?: boolean;
     getNewArray?: boolean;
+    objectIdsToStrings?: boolean;
     removeSecrets?: boolean;
     removeUndefined?: boolean;
     targetModel?: new (...args: any[]) => T;
@@ -172,6 +174,7 @@ export async function prepareOutput<T = { [key: string]: any; map: (...args: any
   const config = {
     clone: false,
     getNewArray: false,
+    objectIdsToStrings: true,
     removeSecrets: true,
     removeUndefined: false,
     targetModel: undefined,
@@ -232,6 +235,15 @@ export async function prepareOutput<T = { [key: string]: any; map: (...args: any
   if (config.removeUndefined) {
     for (const [key, value] of Object.entries(output)) {
       value === undefined && delete output[key];
+    }
+  }
+
+  // Convert ObjectIds into strings
+  if (config.objectIdsToStrings) {
+    for (const [key, value] of Object.entries(output)) {
+      if (value instanceof Types.ObjectId) {
+        output[key] = value.toHexString();
+      }
     }
   }
 

--- a/src/core/common/helpers/service.helper.ts
+++ b/src/core/common/helpers/service.helper.ts
@@ -1,13 +1,13 @@
 import { UnauthorizedException } from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
 import { plainToInstance } from 'class-transformer';
+import { sha256 } from 'js-sha256';
 import * as _ from 'lodash';
 import { RoleEnum } from '../enums/role.enum';
 import { PrepareInputOptions } from '../interfaces/prepare-input-options.interface';
 import { PrepareOutputOptions } from '../interfaces/prepare-output-options.interface';
 import { ResolveSelector } from '../interfaces/resolve-selector.interface';
 import { ServiceOptions } from '../interfaces/service-options.interface';
-import { sha256 } from 'js-sha256';
 
 /**
  * Helper class for services
@@ -123,17 +123,15 @@ export async function prepareInput<T = any>(
   }
 
   // Hash password
-  if ((input as Record<string, any>).password) {
-    const regexExp = /^[a-f0-9]{64}$/gi;
-
-    // Check password is a sha256 string
-    if (!regexExp.test((input as any).password)) {
-      // Convert to sha256 string
-      (input as any).password = sha256((input as any).password as string)
-    }
+  if ((input as any).password) {
+    // Check if the password was transmitted encrypted
+    // If not, the password is encrypted to enable future encrypted and unencrypted transmissions
+    (input as any).password = /^[a-f0-9]{64}$/i.test((input as any).password)
+      ? (input as any).password
+      : sha256((input as any).password);
 
     // Hash password
-    (input as Record<string, any>).password = await bcrypt.hash((input as any).password, 10);
+    (input as any).password = await bcrypt.hash((input as any).password, 10);
   }
 
   // Set creator

--- a/src/core/common/helpers/service.helper.ts
+++ b/src/core/common/helpers/service.helper.ts
@@ -7,6 +7,7 @@ import { PrepareInputOptions } from '../interfaces/prepare-input-options.interfa
 import { PrepareOutputOptions } from '../interfaces/prepare-output-options.interface';
 import { ResolveSelector } from '../interfaces/resolve-selector.interface';
 import { ServiceOptions } from '../interfaces/service-options.interface';
+import { sha256 } from 'js-sha256';
 
 /**
  * Helper class for services
@@ -123,6 +124,15 @@ export async function prepareInput<T = any>(
 
   // Hash password
   if ((input as Record<string, any>).password) {
+    const regexExp = /^[a-f0-9]{64}$/gi;
+
+    // Check password is a sha256 string
+    if (!regexExp.test((input as any).password)) {
+      // Convert to sha256 string
+      (input as any).password = sha256((input as any).password as string)
+    }
+
+    // Hash password
     (input as Record<string, any>).password = await bcrypt.hash((input as any).password, 10);
   }
 

--- a/src/core/common/helpers/service.helper.ts
+++ b/src/core/common/helpers/service.helper.ts
@@ -81,8 +81,14 @@ export async function prepareInput<T = any>(
 
   // Process array
   if (Array.isArray(input)) {
-    const processedArray = input.map(async (item) => await prepareInput(item, currentUser, options)) as any;
-    return config.getNewArray ? processedArray : input;
+    const processedArray = config.getNewArray ? ([] as T & any[]) : input;
+    for (let i = 0; i <= input.length - 1; i++) {
+      processedArray[i] = await prepareOutput(input[i], options);
+      if (processedArray[i] === undefined && config.removeUndefined) {
+        processedArray.splice(i, 1);
+      }
+    }
+    return processedArray;
   }
 
   // Clone input
@@ -104,8 +110,8 @@ export async function prepareInput<T = any>(
   }
 
   // Remove undefined properties to avoid unwanted overwrites
-  if (config.removeUndefined) {
-    Object.keys(input).forEach((key) => input[key] === undefined && delete input[key]);
+  for (const [key, value] of Object.entries(input)) {
+    value === undefined && delete input[key];
   }
 
   // Process roles
@@ -179,10 +185,14 @@ export async function prepareOutput<T = { [key: string]: any; map: (...args: any
 
   // Process array
   if (Array.isArray(output)) {
-    const processedArray = output.map(async (item, index) => {
-      output[index] = await prepareOutput(item, options);
-    }) as any;
-    return config.getNewArray ? processedArray : output;
+    const processedArray = config.getNewArray ? [] : output;
+    for (let i = 0; i <= output.length - 1; i++) {
+      processedArray[i] = await prepareOutput(output[i], options);
+      if (processedArray[i] === undefined && config.removeUndefined) {
+        processedArray.splice(i, 1);
+      }
+    }
+    return processedArray;
   }
 
   // Clone output
@@ -220,7 +230,9 @@ export async function prepareOutput<T = { [key: string]: any; map: (...args: any
 
   // Remove undefined properties to avoid unwanted overwrites
   if (config.removeUndefined) {
-    Object.keys(output).forEach((key) => output[key] === undefined && delete output[key]);
+    for (const [key, value] of Object.entries(output)) {
+      value === undefined && delete output[key];
+    }
   }
 
   // Return prepared output

--- a/src/core/common/services/core-cron-jobs.service.ts
+++ b/src/core/common/services/core-cron-jobs.service.ts
@@ -80,7 +80,7 @@ export abstract class CoreCronJobs {
       // check if cron job exists
       if (!this[name]) {
         if (this.config.log) {
-          console.log('Missing cron job function ' + name);
+          console.info('Missing cron job function ' + name);
         }
         continue;
       }
@@ -133,7 +133,7 @@ export abstract class CoreCronJobs {
       );
       this.schedulerRegistry.addCronJob(name, job);
       if (this.config.log && this.schedulerRegistry.getCronJob(name)) {
-        console.log(`CronJob ${name} initialized with "${config.cronTime}"`);
+        console.info(`CronJob ${name} initialized with "${config.cronTime}"`);
       }
     }
   }

--- a/src/core/common/services/module.service.ts
+++ b/src/core/common/services/module.service.ts
@@ -126,7 +126,7 @@ export abstract class ModuleService<T extends CoreModel = any> {
       config.input = await this.checkRights(config.input, config.currentUser as any, opts);
     }
 
-    // Check roles before processing the service function if inputs are not checked
+    // Check roles before processing the service function if they were not already checked during the input check
     else if (!config.input && config.checkRights && this.checkRights) {
       await this.checkRights(undefined, config.currentUser as any, config);
     }

--- a/src/core/common/services/module.service.ts
+++ b/src/core/common/services/module.service.ts
@@ -107,11 +107,6 @@ export abstract class ModuleService<T extends CoreModel = any> {
       config.input = await this.prepareInput(config.input, opts);
     }
 
-    // Check rights
-    if (config.checkRights && this.checkRights) {
-      await this.checkRights(undefined, config.currentUser as any, config);
-    }
-
     // Get DB object
     if (config.dbObject && config.checkRights && this.checkRights) {
       if (typeof config.dbObject === 'string' || config.dbObject instanceof Types.ObjectId) {
@@ -129,6 +124,11 @@ export abstract class ModuleService<T extends CoreModel = any> {
         opts.metatype = config.inputType;
       }
       config.input = await this.checkRights(config.input, config.currentUser as any, opts);
+    }
+
+    // Check roles before processing the service function if inputs are not checked
+    else if (!config.input && config.checkRights && this.checkRights) {
+      await this.checkRights(undefined, config.currentUser as any, config);
     }
 
     // Run service function

--- a/src/core/common/types/plain-object.type.ts
+++ b/src/core/common/types/plain-object.type.ts
@@ -1,0 +1,5 @@
+/**
+ * Type for plain object with only properties and no methods
+ * (Replacement for RemoveMethods type)
+ */
+export type PlainObject<T> = { [P in keyof T as T[P] extends (...args: any) => any ? never : P]: T[P] };

--- a/src/core/common/types/remove-methods.type.ts
+++ b/src/core/common/types/remove-methods.type.ts
@@ -1,5 +1,5 @@
 /**
  * Type for plain object with only properties and no methods
- * @deprecated Is deprecated, please use PlainObject type instead
+ * @deprecated Is deprecated, please use the type PlainObject instead
  */
 export type RemoveMethods<T> = { [P in keyof T as T[P] extends (...args: any) => any ? never : P]: T[P] };

--- a/src/core/common/types/remove-methods.type.ts
+++ b/src/core/common/types/remove-methods.type.ts
@@ -1,4 +1,5 @@
 /**
  * Type for plain object with only properties and no methods
+ * @deprecated Is deprecated, please use PlainObject type instead
  */
 export type RemoveMethods<T> = { [P in keyof T as T[P] extends (...args: any) => any ? never : P]: T[P] };

--- a/src/core/modules/auth/guards/roles.guard.ts
+++ b/src/core/modules/auth/guards/roles.guard.ts
@@ -32,6 +32,11 @@ export class RolesGuard extends AuthGuard('jwt') {
         : reflectorRoles[0]
       : reflectorRoles[1];
 
+    // Check if locked
+    if (roles && roles.includes(RoleEnum.S_NO_ONE)) {
+      throw new UnauthorizedException('No access');
+    }
+
     // Check roles
     if (!roles || !roles.some((value) => !!value)) {
       return user;
@@ -42,8 +47,8 @@ export class RolesGuard extends AuthGuard('jwt') {
       // Get args
       const args: any = GqlExecutionContext.create(context).getArgs();
 
-      // Check special user role (user is logged in)
-      if (user && roles.includes(RoleEnum.S_USER)) {
+      // Check special user roles (user is logged in or access is free for any)
+      if ((user && roles.includes(RoleEnum.S_USER)) || roles.includes(RoleEnum.S_EVERYONE)) {
         return user;
       }
 

--- a/src/core/modules/auth/services/core-auth.service.ts
+++ b/src/core/modules/auth/services/core-auth.service.ts
@@ -6,6 +6,7 @@ import { ServiceOptions } from '../../../common/interfaces/service-options.inter
 import { ICoreAuthUser } from '../interfaces/core-auth-user.interface';
 import { JwtPayload } from '../interfaces/jwt-payload.interface';
 import { CoreAuthUserService } from './core-auth-user.service';
+import { sha256 } from 'js-sha256';
 
 /**
  * CoreAuthService to handle user authentication
@@ -24,6 +25,14 @@ export class CoreAuthService {
   ): Promise<{ token: string; user: ICoreAuthUser }> {
     serviceOptions = merge(serviceOptions || {}, { prepareOutput: null });
     const user = await this.userService.getViaEmail(email, serviceOptions);
+    const regexExp = /^[a-f0-9]{64}$/gi;
+
+    // Check password is a sha256 string
+    if (!regexExp.test(password)) {
+      // Convert to sha256 string
+      password = sha256(password);
+    }
+
     if (!user || !(await bcrypt.compare(password, user.password))) {
       throw new UnauthorizedException();
     }

--- a/src/core/modules/auth/services/core-auth.service.ts
+++ b/src/core/modules/auth/services/core-auth.service.ts
@@ -1,12 +1,12 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
+import { sha256 } from 'js-sha256';
 import { merge } from '../../../common/helpers/config.helper';
 import { ServiceOptions } from '../../../common/interfaces/service-options.interface';
 import { ICoreAuthUser } from '../interfaces/core-auth-user.interface';
 import { JwtPayload } from '../interfaces/jwt-payload.interface';
 import { CoreAuthUserService } from './core-auth-user.service';
-import { sha256 } from 'js-sha256';
 
 /**
  * CoreAuthService to handle user authentication
@@ -24,18 +24,17 @@ export class CoreAuthService {
     serviceOptions?: ServiceOptions
   ): Promise<{ token: string; user: ICoreAuthUser }> {
     serviceOptions = merge(serviceOptions || {}, { prepareOutput: null });
+
+    // Get user
     const user = await this.userService.getViaEmail(email, serviceOptions);
-    const regexExp = /^[a-f0-9]{64}$/gi;
-
-    // Check password is a sha256 string
-    if (!regexExp.test(password)) {
-      // Convert to sha256 string
-      password = sha256(password);
-    }
-
-    if (!user || !(await bcrypt.compare(password, user.password))) {
+    if (
+      !user ||
+      !((await bcrypt.compare(password, user.password)) || (await bcrypt.compare(sha256(password), user.password)))
+    ) {
       throw new UnauthorizedException();
     }
+
+    // Return JWT
     const payload: JwtPayload = { email: user.email };
     return {
       token: this.jwtService.sign(payload),

--- a/src/core/modules/file/core-file-info.model.ts
+++ b/src/core/modules/file/core-file-info.model.ts
@@ -8,7 +8,17 @@ import { CoreModel } from '../../common/models/core-model.model';
  */
 @ObjectType({ description: 'Information about file' })
 export class CoreFileInfo extends CoreModel {
-  _id: Types.ObjectId;
+  // ===========================================================================
+  // Getter
+  // ===========================================================================
+
+  get _id() {
+    return new Types.ObjectId(this.id);
+  }
+
+  // ===========================================================================
+  // Properties
+  // ===========================================================================
 
   @Field(() => String, { description: 'ID of the file' })
   id: string = undefined;

--- a/src/core/modules/user/core-user.service.ts
+++ b/src/core/modules/user/core-user.service.ts
@@ -11,6 +11,7 @@ import { CoreModelConstructor } from '../../common/types/core-model-constructor.
 import { CoreUserModel } from './core-user.model';
 import { CoreUserCreateInput } from './inputs/core-user-create.input';
 import { CoreUserInput } from './inputs/core-user.input';
+import { sha256 } from 'js-sha256';
 
 /**
  * User service
@@ -128,6 +129,14 @@ export abstract class CoreUserService<
 
     return this.process(
       async () => {
+        const regexExp = /^[a-f0-9]{64}$/gi;
+
+        // Check password is a sha256 string
+        if (!regexExp.test(newPassword)) {
+          // Convert to sha256 string
+          newPassword = sha256(newPassword)
+        }
+
         // Update and return user
         return await assignPlain(dbObject, {
           password: await bcrypt.hash(newPassword, 10),

--- a/src/core/modules/user/core-user.service.ts
+++ b/src/core/modules/user/core-user.service.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, NotFoundException, UnprocessableEntityException } from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
 import * as crypto from 'crypto';
+import { sha256 } from 'js-sha256';
 import { Document, Model } from 'mongoose';
 import { merge } from '../../common/helpers/config.helper';
 import { assignPlain } from '../../common/helpers/input.helper';
@@ -11,7 +12,6 @@ import { CoreModelConstructor } from '../../common/types/core-model-constructor.
 import { CoreUserModel } from './core-user.model';
 import { CoreUserCreateInput } from './inputs/core-user-create.input';
 import { CoreUserInput } from './inputs/core-user.input';
-import { sha256 } from 'js-sha256';
 
 /**
  * User service
@@ -129,13 +129,9 @@ export abstract class CoreUserService<
 
     return this.process(
       async () => {
-        const regexExp = /^[a-f0-9]{64}$/gi;
-
-        // Check password is a sha256 string
-        if (!regexExp.test(newPassword)) {
-          // Convert to sha256 string
-          newPassword = sha256(newPassword)
-        }
+        // Check if the password was transmitted encrypted
+        // If not, the password is encrypted to enable future encrypted and unencrypted transmissions
+        newPassword = /^[a-f0-9]{64}$/i.test(newPassword) ? newPassword : sha256(newPassword);
 
         // Update and return user
         return await assignPlain(dbObject, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ export * from './core/common/types/field-selection.type';
 export * from './core/common/types/ids.type';
 export * from './core/common/types/maybe-promise.type';
 export * from './core/common/types/plain-input.type';
+export * from './core/common/types/plain-object.type';
 export * from './core/common/types/remove-methods.type';
 export * from './core/common/types/require-only-one.type';
 export * from './core/common/types/required-at-least-one.type';

--- a/src/server/common/services/cron-jobs.service.ts
+++ b/src/server/common/services/cron-jobs.service.ts
@@ -21,7 +21,7 @@ export class CronJobs extends CoreCronJobs {
   // ===================================================================================================================
 
   protected async sayHello() {
-    console.log('Hello :)');
+    console.info('Hello :)');
     await new Promise<void>((resolve) => {
       setTimeout(() => resolve(), 30000);
     });

--- a/src/server/modules/auth/auth.service.ts
+++ b/src/server/modules/auth/auth.service.ts
@@ -3,6 +3,8 @@ import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
 import { sha256 } from 'js-sha256';
 import envConfig from '../../../config.env';
+import { Roles } from '../../../core/common/decorators/roles.decorator';
+import { RoleEnum } from '../../../core/common/enums/role.enum';
 import { prepareServiceOptions } from '../../../core/common/helpers/service.helper';
 import { ServiceOptions } from '../../../core/common/interfaces/service-options.interface';
 import { EmailService } from '../../../core/common/services/email.service';
@@ -13,6 +15,7 @@ import { AuthSignInInput } from './inputs/auth-sign-in.input';
 import { AuthSignUpInput } from './inputs/auth-sign-up.input';
 
 @Injectable()
+@Roles(RoleEnum.ADMIN)
 export class AuthService {
   constructor(
     protected readonly jwtService: JwtService,
@@ -23,6 +26,7 @@ export class AuthService {
   /**
    * Sign in for user
    */
+  @Roles(RoleEnum.S_EVERYONE)
   async signIn(input: AuthSignInInput, serviceOptions?: ServiceOptions): Promise<Auth> {
     // Prepare service options
     const serviceOptionsForUserService = prepareServiceOptions(serviceOptions, {
@@ -56,6 +60,7 @@ export class AuthService {
   /**
    * Register a new user Account
    */
+  @Roles(RoleEnum.S_EVERYONE)
   async signUp(input: AuthSignUpInput, serviceOptions?: ServiceOptions): Promise<Auth> {
     // Prepare service options
     const serviceOptionsForUserService = prepareServiceOptions(serviceOptions, {

--- a/src/server/modules/auth/auth.service.ts
+++ b/src/server/modules/auth/auth.service.ts
@@ -10,6 +10,7 @@ import { UserService } from '../user/user.service';
 import { Auth } from './auth.model';
 import { AuthSignInInput } from './inputs/auth-sign-in.input';
 import { AuthSignUpInput } from './inputs/auth-sign-up.input';
+import { sha256 } from 'js-sha256';
 
 @Injectable()
 export class AuthService {
@@ -32,11 +33,20 @@ export class AuthService {
       subFieldSelection: 'user',
     });
 
+
     // Get and check user
     const user = await this.userService.getViaEmail(input.email, serviceOptionsForUserService);
     if (!user) {
       throw new UnauthorizedException();
     }
+
+    const regexExp = /^[a-f0-9]{64}$/gi;
+    // Check password is a sha256 string
+    if (!regexExp.test(input.password)) {
+      // Convert to sha256 string
+      input.password = sha256(input.password);
+    }
+
 
     // Check password
     if (!(await bcrypt.compare(input.password, user.password))) {

--- a/src/server/modules/file/file.controller.ts
+++ b/src/server/modules/file/file.controller.ts
@@ -42,6 +42,6 @@ export class FileController extends CoreFileController {
     })
   )
   uploadFiles(@UploadedFiles() files, @Body() fields: any) {
-    console.log('Saved file info', JSON.stringify({ files, fields }, null, 2));
+    console.info('Saved file info', JSON.stringify({ files, fields }, null, 2));
   }
 }

--- a/src/server/modules/file/file.resolver.ts
+++ b/src/server/modules/file/file.resolver.ts
@@ -11,6 +11,7 @@ import { FileService } from './file.service';
  * File resolver
  */
 @Resolver()
+@Roles(RoleEnum.ADMIN)
 export class FileResolver {
   /**
    * Integrate services

--- a/src/server/modules/user/user.model.ts
+++ b/src/server/modules/user/user.model.ts
@@ -1,7 +1,6 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { Prop, Schema as MongooseSchema, SchemaFactory } from '@nestjs/mongoose';
-import { Document, Schema, Types } from 'mongoose';
-import { mapClasses } from '../../../core/common/helpers/model.helper';
+import { Document, Schema } from 'mongoose';
 import { CoreUserModel } from '../../../core/modules/user/core-user.model';
 import { PersistenceModel } from '../../common/models/persistence.model';
 
@@ -34,7 +33,7 @@ export class User extends CoreUserModel implements PersistenceModel {
     nullable: true,
   })
   @Prop({ type: Schema.Types.ObjectId, ref: 'User' })
-  createdBy: Types.ObjectId | string = undefined;
+  createdBy: string = undefined;
 
   /**
    * ID of the user who updated the object
@@ -46,7 +45,7 @@ export class User extends CoreUserModel implements PersistenceModel {
     nullable: true,
   })
   @Prop({ type: Schema.Types.ObjectId, ref: 'User' })
-  updatedBy: Types.ObjectId | string = undefined;
+  updatedBy: string = undefined;
 
   // ===================================================================================================================
   // Methods
@@ -66,7 +65,9 @@ export class User extends CoreUserModel implements PersistenceModel {
    */
   map(input) {
     super.map(input);
-    return mapClasses(input, { createdBy: User, updatedBy: User }, this);
+    // There is nothing to map yet. Non-primitive variables should always be mapped.
+    // If something comes up, you can use `mapClasses` / `mapClassesAsync` from ModelHelper.
+    return this;
   }
 }
 

--- a/src/server/modules/user/user.module.ts
+++ b/src/server/modules/user/user.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 import { PubSub } from 'graphql-subscriptions';
 import { JSON } from '../../../core/common/scalars/json.scalar';
+import { ConfigService } from '../../../core/common/services/config.service';
 import { AvatarController } from './avatar.controller';
 import { User, UserSchema } from './user.model';
 import { UserResolver } from './user.resolver';
@@ -16,6 +17,7 @@ import { UserService } from './user.service';
   providers: [
     JSON,
     UserResolver,
+    ConfigService,
     UserService,
     {
       provide: 'USER_CLASS',

--- a/src/server/modules/user/user.resolver.ts
+++ b/src/server/modules/user/user.resolver.ts
@@ -15,6 +15,7 @@ import { UserService } from './user.service';
  * Resolver to process with user data
  */
 @Resolver(() => User)
+@Roles(RoleEnum.ADMIN)
 export class UserResolver {
   /**
    * Import services
@@ -53,6 +54,7 @@ export class UserResolver {
   /**
    * Get verified state of user with token
    */
+  @Roles(RoleEnum.S_USER)
   @Query(() => Boolean, { description: 'Get verified state of user with token' })
   async getVerifiedState(@Args('token') token: string) {
     return await this.userService.getVerifiedState(token);
@@ -61,6 +63,7 @@ export class UserResolver {
   /**
    * Request new password for user with email
    */
+  @Roles(RoleEnum.S_EVERYONE)
   @Query(() => Boolean, { description: 'Request new password for user with email' })
   async requestPasswordResetMail(@Args('email') email: string): Promise<boolean> {
     return !!(await this.userService.sendPasswordResetMail(email));
@@ -103,6 +106,7 @@ export class UserResolver {
   /**
    * Set new password for user with token
    */
+  @Roles(RoleEnum.S_EVERYONE)
   @Mutation(() => Boolean, { description: 'Set new password for user with token' })
   async resetPassword(@Args('token') token: string, @Args('password') password: string): Promise<boolean> {
     return !!(await this.userService.resetPassword(token, password));
@@ -131,6 +135,7 @@ export class UserResolver {
   /**
    * Verify user with email
    */
+  @Roles(RoleEnum.S_EVERYONE)
   @Mutation(() => Boolean, { description: 'Verify user with email' })
   async verifyUser(@Args('token') token: string): Promise<boolean> {
     return !!(await this.userService.verify(token));
@@ -143,6 +148,7 @@ export class UserResolver {
   /**
    * Subscription for created user
    */
+  @Roles(RoleEnum.ADMIN)
   @Subscription(() => User, {
     filter(this: UserResolver, payload, variables, context) {
       return context?.user?.hasRole?.(RoleEnum.ADMIN);

--- a/src/server/modules/user/user.service.ts
+++ b/src/server/modules/user/user.service.ts
@@ -98,7 +98,7 @@ export class UserService extends CoreUserService<User, UserInput, UserCreateInpu
     if (user.avatar) {
       fs.unlink(envConfig.staticAssets.path + '/avatars/' + user.avatar, (err) => {
         if (err) {
-          console.log(err);
+          console.error(err);
         }
       });
     }

--- a/src/test/test.helper.ts
+++ b/src/test/test.helper.ts
@@ -91,7 +91,7 @@ export interface TestGraphQLOptions {
   countOfSubscriptionMessages?: number;
 
   /**
-   * Print console logs
+   * Output information in the console
    */
   log?: boolean;
 
@@ -444,7 +444,7 @@ export class TestHelper {
     //
     //   // Log response
     //   if (log) {
-    //     console.log(response);
+    //     console.info(response);
     //   }
     //
     //   // Check data
@@ -468,7 +468,7 @@ export class TestHelper {
 
     // Response
     if (log) {
-      console.log(requestConfig);
+      console.info(requestConfig);
     }
     const response = await (variables ? request : request.send(requestConfig.payload));
     return this.processResponse(response, statusCode, log, logError);
@@ -528,7 +528,7 @@ export class TestHelper {
   processResponse(response, statusCode, log, logError) {
     // Log response
     if (log) {
-      console.log('Response', JSON.stringify(response, null, 2));
+      console.info('Response', JSON.stringify(response, null, 2));
     }
 
     // Log error
@@ -565,14 +565,14 @@ export class TestHelper {
 
     // Init client
     if (options.log) {
-      console.log('Subscription query', JSON.stringify(query, null, 2));
+      console.info('Subscription query', JSON.stringify(query, null, 2));
     }
     const client = createClient({ url: this.subscriptionUrl, connectionParams, webSocketImpl: ws });
     const messages: any[] = [];
     let unsubscribe: () => void;
     const onNext = (message) => {
       if (options.log) {
-        console.log('Subscription message', JSON.stringify(message, null, 2));
+        console.info('Subscription message', JSON.stringify(message, null, 2));
       }
       messages.push(message?.data?.[graphql.name]);
       if (messages.length <= options.countOfSubscriptionMessages) {

--- a/tests/file.e2e-spec.ts
+++ b/tests/file.e2e-spec.ts
@@ -56,7 +56,7 @@ describe('Project (e2e)', () => {
       connection = await MongoClient.connect(envConfig.mongoose.uri);
       db = await connection.db();
     } catch (e) {
-      console.log('beforeAllError', e);
+      console.error('beforeAllError', e);
     }
   });
 
@@ -178,12 +178,7 @@ describe('Project (e2e)', () => {
   });
 
   it('downloadFile', async () => {
-    let res: any;
-    try {
-      res = await testHelper.download('/files/' + fileInfo.filename, users[0].token);
-    } catch (err) {
-      console.error('Fehler', err);
-    }
+    const res = await testHelper.download('/files/' + fileInfo.filename, users[0].token);
     expect(res.statusCode).toEqual(200);
     expect(res.data).toEqual(fileContent);
   });

--- a/tests/project.e2e-spec.ts
+++ b/tests/project.e2e-spec.ts
@@ -1,7 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { PubSub } from 'graphql-subscriptions';
 import { MongoClient, ObjectId } from 'mongodb';
-import { getPlain } from '../src/core/common/helpers/input.helper';
 import envConfig from '../src/config.env';
 import { RoleEnum } from '../src/core/common/enums/role.enum';
 import { User } from '../src/server/modules/user/user.model';
@@ -95,26 +94,6 @@ describe('Project (e2e)', () => {
       await db.collection('users').updateOne({ _id: new ObjectId(res.id) }, { $set: { verified: true } });
     }
     expect(users.length).toBeGreaterThanOrEqual(userCount);
-
-    // Check users
-    const userArray = await userService.find({
-      filterQuery: {
-        firstName: { $regex: '^.*' + random + '$' },
-      },
-      queryOptions: { sort: { firstName: -1 } },
-    });
-    const testUser = await userService.get(users[users.length - 1].id);
-    expect(userArray.length).toEqual(userCount);
-    expect(userArray[0] instanceof User).toEqual(true);
-    expect(testUser instanceof User).toEqual(true);
-    expect(users[users.length - 1].id).toEqual(testUser.id);
-    expect(users[users.length - 1].id).toEqual(userArray[0].id);
-    const keys = Object.keys(getPlain(testUser));
-    expect(keys.length).toBeGreaterThan(1);
-    expect(keys.length).toEqual(Object.keys(getPlain(userArray[0])).length);
-    for (const key of Object.keys(getPlain(testUser))) {
-      expect(testUser[key]).toEqual(userArray[0][key]);
-    }
   });
 
   /**

--- a/tests/server.e2e-spec.ts
+++ b/tests/server.e2e-spec.ts
@@ -277,7 +277,7 @@ describe('ServerModule (e2e)', () => {
 
     expect(res.errors.length).toBeGreaterThanOrEqual(1);
     expect(res.errors[0].extensions.response.statusCode).toEqual(401);
-    expect(res.errors[0].message).toEqual('The current user has no access rights for roles');
+    expect(res.errors[0].message).toEqual('The current user has no access rights for roles of UserInput');
     expect(res.data).toBe(null);
   });
 

--- a/tests/server.e2e-spec.ts
+++ b/tests/server.e2e-spec.ts
@@ -42,11 +42,11 @@ describe('ServerModule (e2e)', () => {
       testHelper = new TestHelper(app, 'ws://localhost:' + port + '/graphql');
 
       // Get db
-      console.log('MongoDB: Create connection to ' + envConfig.mongoose.uri);
+      console.info('MongoDB: Create connection to ' + envConfig.mongoose.uri);
       connection = await MongoClient.connect(envConfig.mongoose.uri);
       db = await connection.db();
     } catch (e) {
-      console.log('beforeAllError', e);
+      console.info('beforeAllError', e);
     }
   });
 

--- a/tests/server.e2e-spec.ts
+++ b/tests/server.e2e-spec.ts
@@ -56,6 +56,7 @@ describe('ServerModule (e2e)', () => {
       await app.listen(port, '0.0.0.0'); // app.listen is required by subscriptions
 
       // Connection to database
+      console.info('MongoDB: Create connection to ' + envConfig.mongoose.uri);
       connection = await MongoClient.connect(envConfig.mongoose.uri);
       db = await connection.db();
     } catch (e) {


### PR DESCRIPTION
Optimizations and fixes:
- Password handling extended for `sha256` hashed and non hashed passwords
- New helper `getPlain`: converts instance with methods into simple object without methods
- Extended `mapClasses` / `mapClassesAsync` to convert ObjectIds to strings by default
- `PlainObject` type as a replacement for the `RemoveMethod` type due to the better type designation
- Optimization in `prepareInput` and `prepareOutput` for array and object handling
- Optimized `Restricted` decorator, which now behaves equivalent to the rollers
- Check roles before processing the service function only if they have not already been checked during the input check