### PR TITLE
Fix duplicate CoreBetterAuthModule.forRoot() import causing DI corrup…

### DIFF
--- a/src/core/modules/auth/core-auth.module.ts
+++ b/src/core/modules/auth/core-auth.module.ts
@@ -53,7 +53,7 @@ export class CoreAuthModule {
           return [{ provide: APP_GUARD, useClass: RolesGuard }];
         })();
 
-    let providers = [
+    let providers: any[] = [
       // [Global] The GraphQLAuthGuard integrates the user into context
       ...rolesGuardProvider,
       {
@@ -81,7 +81,7 @@ export class CoreAuthModule {
       LegacyAuthRateLimitGuard,
     ];
     if (Array.isArray(options?.providers)) {
-      providers = imports.concat(options.providers);
+      providers = providers.concat(options.providers);
     }
 
     // Return CoreAuthModule


### PR DESCRIPTION
…tion

- Add protection against multiple forRoot() calls in CoreBetterAuthModule
  - Cache the dynamic module and return it on subsequent calls
  - Log warning to help developers identify the misconfiguration
  - Skip cache in test environments (VITEST) to allow different test configs
  - Reset cache in reset() method for proper test isolation

- Fix bug in CoreAuthModule.forRoot() where providers were incorrectly replaced with imports when options.providers was provided
  - Changed `imports.concat(options.providers)` to `providers.concat(...)`

This fixes the "Cannot read properties of undefined (reading 'getAll')" error that occurs when both CoreModule.forRoot(envConfig) and a separate IamModule import CoreBetterAuthModule.forRoot(), causing this.reflector to be undefined in RolesGuard.