### PR TITLE
Release 11.26.3

### DIFF
--- a/FRAMEWORK-API.md
+++ b/FRAMEWORK-API.md
@@ -1,6 +1,6 @@
 # @lenne.tech/nest-server — Framework API Reference
 
-> Auto-generated from source code on 2026-06-03 (v11.26.2)
+> Auto-generated from source code on 2026-06-03 (v11.26.3)
 > File: `FRAMEWORK-API.md` — compact, machine-readable API surface for Claude Code
 
 ## CoreModule.forRoot()

--- a/migration-guides/11.26.2-to-11.26.3.md
+++ b/migration-guides/11.26.2-to-11.26.3.md
@@ -1,0 +1,186 @@
+# Migration Guide: 11.26.2 → 11.26.3
+
+## Overview
+
+| Category | Details |
+|----------|---------|
+| **Breaking Changes** | None |
+| **Bugfixes** | `@UnifiedField({ enum: … })` no longer emits a broken, unnamed `$ref` in the generated OpenAPI document under `@nestjs/swagger >= 11.4` — enum fields now produce proper named component schemas (or clean inline enums when `enumName: null` / auto-detection fails) instead of `allOf: [{ $ref: '#/components/schemas/' }]`, which crashed OpenAPI client generators like `@hey-api/openapi-ts` |
+| **New Features** | None |
+| **Migration Effort** | 0 minutes (automatic) — drop-in patch release |
+
+---
+
+## Quick Migration
+
+No code changes required. The fix applies automatically as soon as the package is updated.
+
+```bash
+# Update package
+pnpm add @lenne.tech/nest-server@11.26.3
+
+# Verify build
+pnpm run build
+
+# Run tests
+pnpm test
+
+# (Optional) regenerate REST client SDK against the new OpenAPI document
+pnpm --filter @your-app/api-sdk openapi-ts
+```
+
+---
+
+## What's Fixed in 11.26.3
+
+### OpenAPI: broken empty `$ref` on enum-typed `@UnifiedField` properties
+
+**Affects:** Any project that
+
+- consumes `@lenne.tech/nest-server` together with `@nestjs/swagger >= 11.4` (this repo pinned to `11.4.2`), AND
+- exposes REST endpoints whose DTOs declare enum fields via `@UnifiedField({ enum: … })`, AND
+- runs an OpenAPI client generator (e.g. `@hey-api/openapi-ts`, `openapi-typescript`, `openapi-generator-cli`) against the bundled OpenAPI document.
+
+**Symptom (before 11.26.3):**
+
+The decorator passed `type: () => String` to `@nestjs/swagger` ALONGSIDE `enum` + `enumName`. `@nestjs/swagger <= 11.2` silently tolerated the combination, but `@nestjs/swagger >= 11.4` emits a broken, **unnamed** enum reference and never registers the enum under `components.schemas`:
+
+```jsonc
+// Generated OpenAPI document — BROKEN
+{
+  "components": {
+    "schemas": {
+      "SomeInput": {
+        "properties": {
+          "status": {
+            "allOf": [
+              { "$ref": "#/components/schemas/" }   // ← empty target!
+            ]
+          }
+        }
+      }
+      // ← StatusEnum is missing entirely from components.schemas
+    }
+  }
+}
+```
+
+Downstream tools crash:
+
+```
+@hey-api/openapi-ts: Missing $ref pointer "#/components/schemas/". Token "" does not exist.
+```
+
+**Fix (in 11.26.3):**
+
+`@UnifiedField` no longer sets `swaggerOpts.type` when the field is an enum. `@nestjs/swagger` derives the schema from `enum` + `enumName` correctly:
+
+```jsonc
+// Generated OpenAPI document — CORRECT
+{
+  "components": {
+    "schemas": {
+      "StatusEnum": { "type": "string", "enum": ["draft", "published", "review"] },
+      "SomeInput": {
+        "properties": {
+          "status": {
+            "allOf": [
+              { "$ref": "#/components/schemas/StatusEnum" }   // ← named, resolvable
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Behaviour matrix:**
+
+| `@UnifiedField` form | OpenAPI output before 11.26.3 | OpenAPI output in 11.26.3 |
+|---|---|---|
+| `{ enum: MyEnum, enumName: 'MyEnum' }` | Empty `$ref`, `MyEnum` missing from `components.schemas` | Named `MyEnum` schema, property uses `$ref` |
+| `{ enum: MyEnum }` + `registerEnum(MyEnum, { name: 'MyEnum' })` | Empty `$ref` | Named `MyEnum` schema, property uses `$ref` |
+| `{ enum: MyEnum, enumName: null }` (opt out) | Empty `$ref` | Inline `enum: [...]`, no `$ref`, no named schema |
+| `{ enum: MyEnum }` without registration | Empty `$ref` | Inline `enum: [...]`, no `$ref`, no named schema |
+| Long-form `{ enum: { enum: MyEnum, enumName: 'MyEnum' } }` (deprecated) | Empty `$ref` | Named `MyEnum` schema, property uses `$ref` (deprecation warning unchanged) |
+| Non-enum fields (`String`, `Number`, `Date`, custom classes, …) | Unchanged | Unchanged |
+
+GraphQL schema, class-validator runtime validation (`IsEnum`), Mongoose `@Prop`, and field-level `@Restricted` / `@Roles` behaviour are all bit-for-bit identical to 11.26.2.
+
+---
+
+## Compatibility Notes
+
+- **`@nestjs/swagger <= 11.2` consumers:** The previously emitted `type: () => String` was redundant; removing it produces the same enum schema as before. No observable change.
+- **`@nestjs/swagger >= 11.4` consumers:** The OpenAPI document for enum fields changes from a **broken** empty `$ref` to a **correct** named schema (or clean inline enum). This is strictly a defect fix — any client generator that was previously crashing now succeeds.
+- **OpenAPI client generators / SDK consumers:** After updating, regenerate the SDK once. Enum properties that were previously typed `string` (when the generator silently dropped the broken `$ref`) will now be typed as the proper enum union — review the generated SDK once and adjust call-sites if you relied on the loose `string` type.
+- **GraphQL consumers:** No change. The `Field(...)` factory and enum resolution are untouched.
+- **`@UnifiedField` public API:** Unchanged. All option shapes (`enum: MyEnum`, `enumName`, deprecated long-form `{ enum: { … } }`, `enumName: null`) keep their documented semantics.
+- **Mongoose / class-validator:** Unchanged. `@Prop({ type: baseType })` still applied for enum fields; `IsEnum(...)` is still the authoritative validator.
+- **Vendor-mode consumers:** Same fix lands in `src/core/common/decorators/unified-field.decorator.ts`. Sync via `/lt-dev:backend:update-nest-server-core`. No flatten-fix change required.
+- **Hidden / excluded enum fields (`@UnifiedField({ exclude: true })`):** Unaffected — those still hide from the OpenAPI document via `ApiHideProperty()`.
+
+---
+
+## Verifying the Fix
+
+If you previously hit the empty-`$ref` defect, confirm the regenerated OpenAPI document:
+
+```bash
+# 1. Boot the API and dump the OpenAPI document
+pnpm start &
+curl -s http://localhost:3000/api-json > /tmp/openapi.json
+
+# 2. There must be no empty/unnamed component refs
+grep -F '"$ref": "#/components/schemas/"' /tmp/openapi.json && echo 'BROKEN' || echo 'OK'
+
+# 3. Every enum used in a DTO must appear in components.schemas
+jq '.components.schemas | keys' /tmp/openapi.json
+```
+
+A complete regression test ships in `tests/unified-field-enum-swagger.e2e-spec.ts` and inspects the real document built by `SwaggerModule.createDocument()` for:
+
+- no empty `$ref` anywhere in the document,
+- a named component schema per enum (string / numeric / array / auto-detected / deprecated long-form),
+- correct enum values and property references,
+- inline-enum fallback for `enumName: null` and for unregistered enums (no empty `$ref`).
+
+---
+
+## Troubleshooting
+
+### After updating, my generated SDK still has an empty `$ref` error
+
+Make sure the SDK is regenerated against a **freshly rebuilt** API. Stale `openapi.json` artefacts checked into the consumer repo continue to be broken. Rebuild the API (`pnpm run build`) and re-export the document (`/api-json` or `SwaggerModule.createDocument` snapshot) before running your codegen.
+
+### My enum properties used to be typed `string` in the generated client and now they're a strict union
+
+That is the corrected behaviour — the previous client was generated against a broken document and silently widened the type. Update call-sites to use the enum union (or import the enum from your shared package). If you need the loose `string` type during the rollout, your codegen typically offers an `--enum-style` flag (e.g. `@hey-api/openapi-ts` → `enums: 'javascript'`) to keep the old shape.
+
+### I rely on the deprecated long-form `enum: { enum: MyEnum, enumName: 'MyEnum' }`
+
+It still works and now produces the same named schema as the shortcut form. The deprecation warning emitted at decoration time is unchanged. Plan to migrate to the shortcut form (`enum: MyEnum, enumName: 'MyEnum'`) before a future MINOR removes the long form.
+
+---
+
+## Module Documentation
+
+### Core Common — `@UnifiedField`
+
+- **Decorator:** `src/core/common/decorators/unified-field.decorator.ts`
+- **Architecture notes:** [.claude/rules/architecture.md](../.claude/rules/architecture.md) (Input Validation section)
+- **Reference tests:**
+  - `tests/unified-field-enum-swagger.e2e-spec.ts` — OpenAPI schema regression guard (the contract this release restores)
+  - `tests/unified-field-enum.e2e-spec.ts` — metadata-level enum behaviour
+  - `tests/unified-field-enum-api.e2e-spec.ts` — runtime REST/GraphQL enum behaviour
+
+---
+
+## References
+
+- [Migration Guide 11.26.1 → 11.26.2](./11.26.1-to-11.26.2.md) — Previous release (`COOKIE_PREFIX` env, cross-layer cookie-prefix lockstep)
+- [Architecture rules — Input Validation](../.claude/rules/architecture.md)
+- [@nestjs/swagger 11.4 release notes](https://github.com/nestjs/swagger/releases) — context for the schema-emission change that surfaced the latent defect
+- [@hey-api/openapi-ts](https://heyapi.dev/) — one of the OpenAPI client generators that was crashing on the broken document
+- [nest-server-starter](https://github.com/lenneTech/nest-server-starter) (reference implementation)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lenne.tech/nest-server",
-  "version": "11.26.2",
+  "version": "11.26.3",
   "description": "Modern, fast, powerful Node.js web framework in TypeScript based on Nest with a GraphQL API and a connection to MongoDB (or other databases).",
   "keywords": [
     "node",

--- a/spectaql.yml
+++ b/spectaql.yml
@@ -19,7 +19,7 @@ servers:
 info:
   title: lT Nest Server
   description: Modern, fast, powerful Node.js web framework in TypeScript based on Nest with a GraphQL API and a connection to MongoDB (or other databases).
-  version: 11.26.2
+  version: 11.26.3
   contact:
     name: lenne.Tech GmbH
     url: https://lenne.tech

--- a/src/core/common/decorators/unified-field.decorator.ts
+++ b/src/core/common/decorators/unified-field.decorator.ts
@@ -408,13 +408,19 @@ export function UnifiedField(opts: UnifiedFieldOptions = {}): PropertyDecorator 
       swaggerOpts.required = true;
     }
 
-    // Set type for swagger
-    if (baseType) {
-      if (normalizedEnum) {
-        swaggerOpts.type = () => String;
-      } else {
-        swaggerOpts.type = baseType;
-      }
+    // Set type for swagger.
+    //
+    // For enum fields we deliberately do NOT set `type`: @nestjs/swagger derives
+    // the schema from `enum` + `enumName` (set further below). Passing
+    // `type: () => String` ALONGSIDE `enum`/`enumName` makes @nestjs/swagger
+    // >= 11.4 emit a broken, UNNAMED enum reference
+    // (`allOf: [{ $ref: '#/components/schemas/' }]`) and never adds the enum to
+    // `components.schemas`. That crashes OpenAPI client generators — e.g.
+    // @hey-api/openapi-ts fails with «Missing $ref pointer "#/components/schemas/"».
+    // (On @nestjs/swagger <= 11.2 the extra `type` was tolerated, which is why
+    // this only surfaced after a swagger bump.)
+    if (baseType && !normalizedEnum) {
+      swaggerOpts.type = baseType;
     }
 
     // Set description

--- a/tests/unified-field-enum-swagger.e2e-spec.ts
+++ b/tests/unified-field-enum-swagger.e2e-spec.ts
@@ -1,0 +1,243 @@
+/**
+ * UnifiedField Enum — OpenAPI (Swagger) schema generation
+ *
+ * Regression guard for the bug where an enum-typed `@UnifiedField` produced a
+ * BROKEN, UNNAMED enum reference in the generated OpenAPI document:
+ *
+ *   "status": { "allOf": [{ "$ref": "#/components/schemas/" }], ... }   // empty name!
+ *
+ * and never added the enum to `components.schemas`. The empty `$ref` crashes
+ * OpenAPI client generators (e.g. @hey-api/openapi-ts:
+ * «Missing $ref pointer "#/components/schemas/". Token "" does not exist.»).
+ *
+ * Root cause: the decorator set `swaggerOpts.type = () => String` ALONGSIDE
+ * `enum` + `enumName`. @nestjs/swagger <= 11.2 tolerated it; >= 11.4 emits the
+ * broken unnamed ref. The fix drops `type` for enum fields so the enum +
+ * enumName drive a proper named schema.
+ *
+ * These tests inspect the REAL OpenAPI document built by
+ * `SwaggerModule.createDocument` — the exact artifact a client generator
+ * consumes — so the empty-ref defect cannot reappear unnoticed.
+ */
+import 'reflect-metadata';
+
+import { Body, Controller, INestApplication, Module, Post } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { UnifiedField } from '../src/core/common/decorators/unified-field.decorator';
+import { registerEnum } from '../src/core/common/helpers/register-enum.helper';
+
+// =============================================================================
+// Test enums
+// =============================================================================
+
+enum SwaggerStatusEnum {
+  DRAFT = 'draft',
+  PUBLISHED = 'published',
+  REVIEW = 'review',
+}
+
+enum SwaggerPriorityEnum {
+  HIGH = 30,
+  LOW = 10,
+  MEDIUM = 20,
+}
+
+enum SwaggerTagEnum {
+  A = 'a',
+  B = 'b',
+}
+
+enum SwaggerAutoEnum {
+  OFF = 'off',
+  ON = 'on',
+}
+
+// Long-form deprecated API: `enum: { enum: X, enumName: 'Y' }` — still
+// supported for backwards compatibility, emits a deprecation warning at
+// decoration time. Must produce a NAMED schema just like the shortcut form.
+enum SwaggerLegacyEnum {
+  ALPHA = 'alpha',
+  BETA = 'beta',
+}
+
+// Explicit-disable path: `enumName: null` must produce an INLINE enum (no
+// named component schema) but MUST NOT emit an empty `$ref`.
+enum SwaggerInlineEnum {
+  KEEP = 'keep',
+  SKIP = 'skip',
+}
+
+// Auto-detection FAILURE path: this enum is intentionally NOT registered and
+// has no explicit `enumName`. `getEnumName()` returns undefined, so swagger
+// receives `enumName: undefined` and must emit an INLINE enum WITHOUT an
+// empty `$ref` (this is the exact crash trigger we are guarding against).
+enum SwaggerUnregisteredEnum {
+  X = 'x',
+  Y = 'y',
+}
+
+// Auto-detection path: register the enum (mirrors `registerEnums()` setup) so
+// the decorator can resolve its name WITHOUT an explicit `enumName`.
+registerEnum(SwaggerAutoEnum, { graphql: false, name: 'SwaggerAutoEnum' });
+
+// =============================================================================
+// Test input — every enum variant that must produce a NAMED schema
+// =============================================================================
+
+class SwaggerEnumInput {
+  // Shortcut form with explicit enumName (the form kit projects use).
+  @UnifiedField({ description: 'string enum', enum: SwaggerStatusEnum, enumName: 'SwaggerStatusEnum', isOptional: true })
+  status?: SwaggerStatusEnum;
+
+  // Numeric enum with explicit enumName.
+  @UnifiedField({ description: 'numeric enum', enum: SwaggerPriorityEnum, enumName: 'SwaggerPriorityEnum', isOptional: true })
+  priority?: SwaggerPriorityEnum;
+
+  // Array enum with explicit enumName (array fields must declare their element type).
+  @UnifiedField({
+    description: 'array enum',
+    enum: SwaggerTagEnum,
+    enumName: 'SwaggerTagEnum',
+    isArray: true,
+    isOptional: true,
+    type: () => SwaggerTagEnum,
+  })
+  tags?: SwaggerTagEnum[];
+
+  // No enumName — name resolved via registerEnum auto-detection.
+  @UnifiedField({ description: 'auto enum', enum: SwaggerAutoEnum, isOptional: true })
+  auto?: SwaggerAutoEnum;
+
+  // Deprecated long-form: `enum: { enum: X, enumName: 'Y' }`.
+  // Emits a console.warn but must still produce a NAMED schema.
+  @UnifiedField({
+    description: 'legacy long-form enum',
+    enum: { enum: SwaggerLegacyEnum, enumName: 'SwaggerLegacyEnum' },
+    isOptional: true,
+  })
+  legacy?: SwaggerLegacyEnum;
+
+  // Explicit `enumName: null` — opt out of named schema. Must produce
+  // an INLINE enum (no $ref) and NOT emit an empty `$ref`.
+  @UnifiedField({ description: 'inline enum', enum: SwaggerInlineEnum, enumName: null, isOptional: true })
+  inline?: SwaggerInlineEnum;
+
+  // Unregistered enum without enumName — auto-detection finds nothing.
+  // Must NOT crash, must NOT emit an empty `$ref`, schema becomes inline.
+  @UnifiedField({ description: 'unregistered enum', enum: SwaggerUnregisteredEnum, isOptional: true })
+  unregistered?: SwaggerUnregisteredEnum;
+}
+
+@Controller('swagger-enum')
+class SwaggerEnumController {
+  @Post()
+  create(@Body() body: SwaggerEnumInput) {
+    return body;
+  }
+}
+
+@Module({ controllers: [SwaggerEnumController] })
+class SwaggerEnumModule {}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/** Recursively collect every `$ref` string in the document. */
+function collectRefs(node: unknown, acc: string[] = []): string[] {
+  if (Array.isArray(node)) {
+    for (const item of node) collectRefs(item, acc);
+  } else if (node && typeof node === 'object') {
+    for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+      if (key === '$ref' && typeof value === 'string') acc.push(value);
+      else collectRefs(value, acc);
+    }
+  }
+  return acc;
+}
+
+/** Resolve the enum schema name a property points at (handles `allOf` + direct `$ref`). */
+function refTarget(prop: any): string | undefined {
+  const ref: string | undefined = prop?.$ref ?? prop?.allOf?.[0]?.$ref ?? prop?.items?.$ref ?? prop?.items?.allOf?.[0]?.$ref;
+  return ref ? ref.replace('#/components/schemas/', '') : undefined;
+}
+
+// =============================================================================
+// Test suite
+// =============================================================================
+
+describe('UnifiedField enum — OpenAPI schema generation', () => {
+  let app: INestApplication;
+  let document: any;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({ imports: [SwaggerEnumModule] }).compile();
+    app = moduleRef.createNestApplication({ logger: false });
+    await app.init();
+    const config = new DocumentBuilder().setTitle('enum-spec-test').setVersion('1.0').build();
+    document = SwaggerModule.createDocument(app, config);
+  });
+
+  afterAll(async () => {
+    if (app) await app.close();
+  });
+
+  it('produces NO empty/unnamed $ref anywhere in the document (the crash trigger)', () => {
+    const refs = collectRefs(document);
+    const empty = refs.filter((r) => r.replace(/\/+$/, '').endsWith('schemas') || r === '#/components/schemas/');
+    expect(empty).toEqual([]);
+  });
+
+  it('registers a named component schema for every enum (string, numeric, array, auto-detected, long-form)', () => {
+    const schemas = document.components?.schemas ?? {};
+    expect(schemas).toHaveProperty('SwaggerStatusEnum');
+    expect(schemas).toHaveProperty('SwaggerPriorityEnum');
+    expect(schemas).toHaveProperty('SwaggerTagEnum');
+    expect(schemas).toHaveProperty('SwaggerAutoEnum');
+    expect(schemas).toHaveProperty('SwaggerLegacyEnum');
+  });
+
+  it('the named enum schemas carry the correct values (order-independent)', () => {
+    const schemas = document.components.schemas;
+    const sortedValues = (name: string) => [...schemas[name].enum].sort();
+    expect(sortedValues('SwaggerStatusEnum')).toEqual(['draft', 'published', 'review']);
+    expect(sortedValues('SwaggerPriorityEnum')).toEqual([10, 20, 30]);
+    expect(sortedValues('SwaggerTagEnum')).toEqual(['a', 'b']);
+    expect(sortedValues('SwaggerAutoEnum')).toEqual(['off', 'on']);
+    expect(sortedValues('SwaggerLegacyEnum')).toEqual(['alpha', 'beta']);
+  });
+
+  it('each named-enum property references its component schema (no inline duplication, no empty ref)', () => {
+    const props = document.components.schemas.SwaggerEnumInput.properties;
+    expect(refTarget(props.status)).toBe('SwaggerStatusEnum');
+    expect(refTarget(props.priority)).toBe('SwaggerPriorityEnum');
+    expect(refTarget(props.auto)).toBe('SwaggerAutoEnum');
+    expect(refTarget(props.legacy)).toBe('SwaggerLegacyEnum');
+    // Array enum: the items reference the named schema.
+    expect(props.tags.type).toBe('array');
+    expect(refTarget(props.tags)).toBe('SwaggerTagEnum');
+  });
+
+  it('opt-out via `enumName: null` produces an INLINE enum (no $ref, no named component)', () => {
+    const props = document.components.schemas.SwaggerEnumInput.properties;
+    const schemas = document.components.schemas;
+    // No named schema is registered for the opted-out enum.
+    expect(schemas).not.toHaveProperty('SwaggerInlineEnum');
+    // Property carries the enum values inline and has no $ref.
+    expect(refTarget(props.inline)).toBeUndefined();
+    expect([...(props.inline.enum ?? [])].sort()).toEqual(['keep', 'skip']);
+  });
+
+  it('unregistered enum without `enumName` falls back to an INLINE enum WITHOUT an empty $ref', () => {
+    const props = document.components.schemas.SwaggerEnumInput.properties;
+    const schemas = document.components.schemas;
+    // Auto-detection found no name → no named schema is registered.
+    expect(schemas).not.toHaveProperty('SwaggerUnregisteredEnum');
+    // The crash trigger: an empty `$ref` would have appeared here on the broken path.
+    expect(refTarget(props.unregistered)).toBeUndefined();
+    expect([...(props.unregistered.enum ?? [])].sort()).toEqual(['x', 'y']);
+  });
+});


### PR DESCRIPTION
Prevent broken unnamed enum `$ref` in OpenAPI output by skipping `swaggerOpts.type` when an enum is set