### PR TITLE
chore: make `tsc --noEmit` clean again — and fix the one real bug it was hiding

### DIFF
--- a/scripts/generate-framework-api.ts
+++ b/scripts/generate-framework-api.ts
@@ -8,10 +8,10 @@
 
 import { Project, type InterfaceDeclaration } from 'ts-morph';
 import { readFileSync, writeFileSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
+// The package is CommonJS (no "type": "module"), so tsx runs this as CJS and __dirname is native.
+// An import.meta.url shim would not typecheck against the root tsconfig (module: commonjs).
 const ROOT = resolve(__dirname, '..');
 const OUTPUT = resolve(ROOT, 'FRAMEWORK-API.md');
 

--- a/tests/unit/performance-caches.spec.ts
+++ b/tests/unit/performance-caches.spec.ts
@@ -728,8 +728,10 @@ describe('Native access security gates', () => {
   });
 
   function createTestService(mockModel: any) {
+    // CrudService is resolved at runtime via a dynamic import, so its compile-time type is `any`.
+    // TypeScript rejects `override` against an `any` base (TS4113); the method still overrides at runtime.
     class TestService extends CrudService {
-      override get() { return null; }
+      get() { return null; }
       callCollection(reason: string) { return this.getNativeCollection(reason); }
       callConnection(reason: string) { return this.getNativeConnection(reason); }
     }

--- a/tests/unit/unified-field-whitelist.spec.ts
+++ b/tests/unit/unified-field-whitelist.spec.ts
@@ -35,7 +35,7 @@ class ChildInput extends BaseInput {
 
 class ChildWithExclude extends BaseInput {
   @UnifiedField({ exclude: true })
-  override email?: string;
+  override email?: string = undefined;
 
   @UnifiedField({ description: 'Phone', isOptional: true })
   phone?: string;
@@ -43,12 +43,12 @@ class ChildWithExclude extends BaseInput {
 
 class GrandchildReEnable extends ChildWithExclude {
   @UnifiedField({ exclude: false, description: 'Email re-enabled', isOptional: true })
-  override email?: string;
+  override email?: string = undefined;
 }
 
 class ChildImplicitOverrideAttempt extends ChildWithExclude {
   @UnifiedField({ description: 'Email implicit', isOptional: true })
-  override email?: string;
+  override email?: string = undefined;
 }
 
 class NoUnifiedFieldClass {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,15 @@
     "incremental": true,
     "noImplicitOverride": true,
     "skipLibCheck": true,
-    "types": ["vitest/globals", "node"]
+    "types": [
+      "vitest/globals",
+      "node"
+    ]
   },
-  "exclude": ["node_modules", "dist"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "vite.config.ts",
+    "src/core/modules/migrate/templates/migration-project.template.ts"
+  ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
       adapter: 'nest',
       appPath: './src/main.ts',
       exportName: 'viteNodeApp',
-      tsCompiler: 'esbuild',
+      tsCompiler: 'swc',
     }),
   ],
   server: {


### PR DESCRIPTION
## Problem

`tsc --noEmit -p tsconfig.json` reported **8 errors on `develop`**. Nothing in the check chain runs it — `nest build` uses `tsconfig.build.json`, which already excludes the two problem files — so the errors only ever surfaced as red squiggles in the editor. They were ignored long enough that **a genuine bug hid among them**.

## The real bug

`vite.config.ts` sets `tsCompiler: 'esbuild'`, but `vite-plugin-node@8` narrowed `SupportedTSCompiler` to `'vite' | 'swc'`:

```ts
// node_modules/vite-plugin-node/dist/index.d.ts:17
export declare type SupportedTSCompiler = 'vite' | 'swc';
```

The config would not work if anyone ran it. Switched to `'swc'`, which the project already uses elsewhere (`nest start -b swc`).

## The rest — fixed at the root, not silenced

| File | Error | Fix |
|---|---|---|
| `scripts/generate-framework-api.ts` | `import.meta` cannot typecheck under `module: commonjs` (TS1343) | The package **is** CommonJS (no `"type": "module"`), so tsx runs the script as CJS and `__dirname` is native — the `fileURLToPath(import.meta.url)` shim was never needed. Removed. |
| `vite.config.ts`, `migration-project.template.ts` | `vite@8` is ESM-only and unresolvable under `moduleResolution: node` (which `module: commonjs` forces); the template deliberately imports `@lenne.tech/nest-server` because it is copied into consumer projects | Excluded from the root tsconfig, mirroring `tsconfig.build.json` |
| `tests/unit/performance-caches.spec.ts:732` | `override` against a base class whose compile-time type is `any` (it comes from a dynamic import) — TS rejects this outright (TS4113) | Dropped the modifier; the method still overrides at runtime |
| `tests/unit/unified-field-whitelist.spec.ts` ×3 | `email` redeclared without an initializer (TS2612) | Added `= undefined`, matching every Input class in the codebase |

**Note on the approach:** a separate ESM `tsconfig.json` for `scripts/` is not an option — `scripts/init-server.ts` imports `src/`, which would drag the whole `import x = require(...)` tree into ESM mode (26× TS1202). Fixing the shim at the source is the only clean route.

## Verification

- `tsc --noEmit` → **0 errors** (was 8)
- `npx tsx scripts/generate-framework-api.ts` still runs and regenerates the file
- Full `pnpm run check` green: audit, format, lint, tests, build, server-start

## Why separate from #559

Pure hygiene, unrelated to the 401/403 work. Reviewable and revertable on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)