### PR TITLE
11.31.0: grouped check report and orchestrator parity

### DIFF
--- a/FRAMEWORK-API.md
+++ b/FRAMEWORK-API.md
@@ -1,6 +1,6 @@
 # @lenne.tech/nest-server — Framework API Reference
 
-> Auto-generated from source code on 2026-07-18 (v11.29.1)
+> Auto-generated from source code on 2026-07-18 (v11.30.0)
 > File: `FRAMEWORK-API.md` — compact, machine-readable API surface for Claude Code
 
 ## CoreModule.forRoot()

--- a/migration-guides/11.29.x-to-11.30.x.md
+++ b/migration-guides/11.29.x-to-11.30.x.md
@@ -7,7 +7,7 @@
 | **Breaking Changes** | None in nest-server's own API. Two transitive changes may affect projects: `@nestjs/websockets` removed from dependencies; `@nestjs/swagger` 11.4.6 blocks deep imports |
 | **New Features** | None (dependency maintenance release) |
 | **Bugfixes** | Dependency updates incl. security-relevant `ws` 8.21.1 override; 6 obsolete pnpm overrides removed |
-| **Migration Effort** | Very Low (~5 minutes) — most projects need no changes |
+| **Migration Effort** | Very Low — most projects need no changes |
 
 ---
 

--- a/migration-guides/11.30.x-to-11.31.x.md
+++ b/migration-guides/11.30.x-to-11.31.x.md
@@ -1,0 +1,38 @@
+# Migration Guide: 11.30.x → 11.31.x
+
+## Overview
+
+| Category | Details |
+|----------|---------|
+| **Breaking Changes** | None |
+| **New Features** | `pnpm run check` steps report grouped by project (monorepo / api / app); orchestrator parity across all lt starters |
+| **Bugfixes** | Root-only chain steps now run correctly when workspace members exist |
+| **Migration Effort** | None — no code changes required |
+
+---
+
+## Quick Migration
+
+```bash
+# Update package
+npm install @lenne.tech/nest-server@11.31.x
+
+# Verify build
+npm run build
+
+# Run tests
+npm test
+```
+
+No code changes required in any project.
+
+---
+
+## What's New in 11.31.x
+
+### Grouped check report
+
+`pnpm run check` now groups its steps report by project (monorepo root, api,
+app), so in a fullstack workspace you immediately see which project a failing
+step belongs to. The check orchestrator also behaves identically across all
+lt starters (same chain semantics, same root-only step handling).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lenne.tech/nest-server",
-  "version": "11.30.0",
+  "version": "11.31.0",
   "description": "Modern, fast, powerful Node.js web framework in TypeScript based on Nest with a GraphQL API and a connection to MongoDB (or other databases).",
   "keywords": [
     "node",

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -671,10 +671,29 @@ function report(started, results) {
   console.log(C.green(bar));
 
   console.log(`\n${C.bold("Steps")}`);
-  for (const r of results.filter((x) => x.kind !== "audit")) {
-    console.log(
-      `  ${C.green("✓")} ${`${shortRel(r.project)} · ${r.label}`.padEnd(26)}${metricSuffix(r) || "  "} ${C.dim(`(${fmtDuration(r.dur)})`)}`,
-    );
+  const steps = results.filter((x) => x.kind !== "audit");
+  // Group by project when more than one is involved: workspace-level steps
+  // (hoisted install/audit, root-only checks) under "monorepo", then one block
+  // per member. Steps within a project run sequentially, so per-group order is
+  // chain order. A single-project run keeps the flat list — a header is noise.
+  const stepGroups = [...new Set(steps.map((r) => r.project))].sort((a, b) =>
+    a === "." ? -1 : b === "." ? 1 : shortRel(a).localeCompare(shortRel(b)),
+  );
+  if (stepGroups.length > 1) {
+    for (const project of stepGroups) {
+      console.log(`  ${C.bold(project === "." ? "monorepo" : shortRel(project))}`);
+      for (const r of steps.filter((x) => x.project === project)) {
+        console.log(
+          `    ${C.green("✓")} ${r.label.padEnd(24)}${metricSuffix(r) || "  "} ${C.dim(`(${fmtDuration(r.dur)})`)}`,
+        );
+      }
+    }
+  } else {
+    for (const r of steps) {
+      console.log(
+        `  ${C.green("✓")} ${`${shortRel(r.project)} · ${r.label}`.padEnd(26)}${metricSuffix(r) || "  "} ${C.dim(`(${fmtDuration(r.dur)})`)}`,
+      );
+    }
   }
 
   console.log(

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -380,9 +380,23 @@ function asProject(rel, check) {
   return { check, dir: rel === "." ? ROOT : join(ROOT, rel), name: pkg.name || rel, rel };
 }
 
-// Workspace sub-projects whose `check` is a real chain; if there are none (a
+// Workspace sub-projects and their real check chain; if there are none (a
 // single-package repo), fall back to the root project — whose real chain lives
 // in `check:raw`, because the root `check` is THIS wrapper.
+//
+// A member's `check` is frequently THIS wrapper too: the lt starters ship their
+// own scripts/check.mjs so they also work standalone (`lt server create`), and
+// `lt fullstack init` clones them verbatim into projects/*. Treating that as
+// "no real chain" silently dropped EVERY member — the run then fell back to the
+// root, whose chain is just `pnpm -r run check`, and reported the whole
+// monorepo as one opaque step with "no test step / 0 passed" while the members'
+// tests were in fact running, unseen. So resolve a member exactly like the root:
+// wrapper `check` means the real chain lives in `check:raw`.
+function realChain(pkg) {
+  if (!IS_ORCHESTRATOR(pkg.scripts?.check)) return pkg.scripts?.check ?? null;
+  return pkg.scripts?.["check:raw"] ?? null;
+}
+
 function discoverProjects() {
   const projects = [];
   for (const glob of workspaceGlobs()) {
@@ -393,15 +407,29 @@ function discoverProjects() {
       } catch {
         continue;
       }
-      if (!IS_ORCHESTRATOR(pkg.scripts?.check)) projects.push(asProject(rel, pkg.scripts.check));
+      const chain = realChain(pkg);
+      if (chain) projects.push(asProject(rel, chain));
     }
   }
+  const root = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8"));
+  const rootChain =
+    root.scripts?.["check:raw"] ??
+    (IS_ORCHESTRATOR(root.scripts?.check) ? null : root.scripts?.check);
   if (projects.length === 0) {
-    const root = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8"));
-    const chain =
-      root.scripts?.["check:raw"] ??
-      (IS_ORCHESTRATOR(root.scripts?.check) ? null : root.scripts?.check);
-    if (chain) projects.push(asProject(".", chain));
+    if (rootChain) projects.push(asProject(".", rootChain));
+  } else if (rootChain) {
+    // With members present, the root's own chain must not be dropped: beyond
+    // install/audit (hoisted later) and the member fan-out (replaced by the
+    // member expansion above) it may carry root-ONLY steps — in the assembled
+    // monorepo that is `check:workspace` / `check:pin`, which exist precisely
+    // for the case where members are present. Strip the fan-out command and
+    // keep whatever remains as a root project.
+    const ownSteps = rootChain
+      .split("&&")
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .filter((c) => !/\bpnpm\s+(?:-r|--recursive)\b.*\brun\s+check\b/.test(c));
+    if (ownSteps.length) projects.unshift(asProject(".", ownSteps.join(" && ")));
   }
   if (PROJECT_FILTERS.length)
     return projects.filter((p) =>

--- a/spectaql.yml
+++ b/spectaql.yml
@@ -19,7 +19,7 @@ servers:
 info:
   title: lT Nest Server
   description: Modern, fast, powerful Node.js web framework in TypeScript based on Nest with a GraphQL API and a connection to MongoDB (or other databases).
-  version: 11.29.1
+  version: 11.30.0
   contact:
     name: lenne.Tech GmbH
     url: https://lenne.tech


### PR DESCRIPTION
Grouped `pnpm run check` steps report (monorepo / api / app) and check-orchestrator parity across the lt starter family. No API changes, no code changes required in consuming projects. Migration guide: migration-guides/11.30.x-to-11.31.x.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)