### PR TITLE
11.31.1: extension-agnostic migration identity + strict mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -152,3 +152,15 @@ SMTP_PASS=smtp-password
 # NSC__SYSTEM_SETUP__INITIAL_ADMIN__EMAIL=admin@example.com
 # NSC__SYSTEM_SETUP__INITIAL_ADMIN__PASSWORD=YourSecurePassword123!
 # NSC__SYSTEM_SETUP__INITIAL_ADMIN__NAME=Admin
+
+
+# =============================================================================
+# Migrations (optional)
+# =============================================================================
+# Strict integrity mode: fail `migrate up`/`list` when a migration recorded in the
+# state store has no file on disk (default: tolerate with a warning, so deleting
+# old, git-tracked migration files never blocks boot). Recommended `true` for
+# immutable production images — a missing file there means a broken build or a
+# state-store mismatch. Accepts 1|true|yes (case-insensitive).
+
+# NSC__MIGRATE__STRICT=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,8 @@ docker build --build-arg API_DIR=projects/api -t api .   # Monorepo
 Key files: `Dockerfile`, `docker-entrypoint.sh` (migrations + server start), `.dockerignore`
 
 The migration store uses `NSC__MONGOOSE__URI` env var (not `config.env.ts`) for Docker compatibility.
+Set `NSC__MIGRATE__STRICT=true` in production images to fail the boot when a recorded migration
+file is missing (default: tolerate with a warning) — see `src/core/modules/migrate/README.md`.
 
 ## Environment Configuration
 

--- a/FRAMEWORK-API.md
+++ b/FRAMEWORK-API.md
@@ -1,6 +1,6 @@
 # @lenne.tech/nest-server — Framework API Reference
 
-> Auto-generated from source code on 2026-07-18 (v11.30.0)
+> Auto-generated from source code on 2026-07-19 (v11.31.0)
 > File: `FRAMEWORK-API.md` — compact, machine-readable API surface for Claude Code
 
 ## CoreModule.forRoot()

--- a/FRAMEWORK-API.md
+++ b/FRAMEWORK-API.md
@@ -1,6 +1,6 @@
 # @lenne.tech/nest-server — Framework API Reference
 
-> Auto-generated from source code on 2026-07-19 (v11.31.0)
+> Auto-generated from source code on 2026-07-19 (v11.31.1)
 > File: `FRAMEWORK-API.md` — compact, machine-readable API surface for Claude Code
 
 ## CoreModule.forRoot()

--- a/migration-guides/11.31.0-to-11.31.1.md
+++ b/migration-guides/11.31.0-to-11.31.1.md
@@ -1,0 +1,89 @@
+# Migration Guide: 11.31.0 → 11.31.1
+
+> Note: written on the feature branch (`feature/migrate-safe-ts-js-transition`).
+> If the release lands under a different version number, rename this file accordingly.
+
+## Overview
+
+| Category | Details |
+|----------|---------|
+| **Breaking Changes** | None |
+| **New Features** | Extension-agnostic migration identity (safe ts-node → compiled-JS transition); strict integrity mode (`--strict` / `NSC__MIGRATE__STRICT` / `MigrationRunnerOptions.strict`); `status()` reports `missing` files; `migrate list` annotates missing files |
+| **Bugfixes** | Co-present `foo.ts` + `foo.js` no longer execute twice in one `up()` run (deduplicated by identity, `.js` wins) |
+| **Migration Effort** | None — no code changes required. Optional: enable strict mode in production images |
+
+---
+
+## Quick Migration
+
+```bash
+# Update package
+npm install @lenne.tech/nest-server@11.31.1
+
+# Verify build
+npm run build
+
+# Run tests
+npm test
+```
+
+No code changes required in any project.
+
+---
+
+## What's New in 11.31.1
+
+### Extension-agnostic migration identity (safe ts-node → compiled-JS transition)
+
+`migrate up`, `migrate down`, and `migrate list` now compare migrations by their
+timestamped file stem WITHOUT the `.ts`/`.js` extension. A migration recorded as
+`1699-foo.ts` (run via ts-node) matches the compiled `1699-foo.js` in a production
+image — already-applied migrations are no longer treated as "pending" and re-run
+after switching the image to compiled JavaScript. No state rewrite is needed;
+existing databases keep working as-is.
+
+If both `foo.ts` and `foo.js` are present in the migrations directory (e.g. an
+overlapping `outDir`), they now count as ONE migration: only the `.js` file is
+loaded and executed, with a warning. Previously both files would have executed.
+
+Note: the legacy `synchronizedUp()` helper drives the external `migrate` package's
+own state handling and keeps raw-filename identity — the new semantics apply to the
+`MigrationRunner`/built-in CLI path only.
+
+### Missing migration files tolerated by default (up/list)
+
+Old, already-applied migration files can be deleted (they live in git and can be
+restored). `migrate up` no longer needs their files to be present:
+
+- Default: `up` warns (`[migrate] N recorded migration file(s) missing — tolerated`) and continues, so the server still boots. Previously such entries were silently ignored — log-scraping setups will see a NEW warning.
+- `migrate list` marks affected entries with `(file missing)` and `status()` additionally returns them in a new `missing: string[]` field (additive, backward compatible).
+- `migrate down` ALWAYS fails hard when the rollback file is missing — unchanged from 11.31.0, with a clearer message (`… restore the file from git to roll back.`). Rollback is an explicit operator action, never a boot path.
+
+### Strict integrity mode (opt-in)
+
+Turn the tolerated drift into a hard error (`up` throws, `list` exits non-zero):
+
+| Activation path | Scope |
+|-----------------|-------|
+| `--strict` CLI flag | single invocation |
+| `NSC__MIGRATE__STRICT=1\|true\|yes` env var (case-insensitive) | CLI **and** programmatic `MigrationRunner` instances |
+| `new MigrationRunner({ strict: true, ... })` | programmatic |
+
+**Recommended for production images:** set `NSC__MIGRATE__STRICT=true`. In an
+immutable image, a recorded-but-missing migration file can only mean a broken build
+or a state-store mismatch — refusing to boot is the correct reaction there.
+
+---
+
+## Compatibility Notes
+
+- `status()` return type gained a `missing: string[]` field. Code that destructures
+  only `completed`/`pending` continues to work unchanged.
+- **Vendor mode:** `src/core/modules/migrate/migration-runner.ts` and
+  `src/core/modules/migrate/cli/migrate-cli.ts` are an atomic pair — sync BOTH
+  files together (the CLI passes `strict` into the runner's options interface and
+  imports `parseStrictEnv` from the runner).
+
+## Module Documentation
+
+- [Migrate module README](../src/core/modules/migrate/README.md) — see "Migration Identity & Strict Mode"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lenne.tech/nest-server",
-  "version": "11.31.0",
+  "version": "11.31.1",
   "description": "Modern, fast, powerful Node.js web framework in TypeScript based on Nest with a GraphQL API and a connection to MongoDB (or other databases).",
   "keywords": [
     "node",

--- a/spectaql.yml
+++ b/spectaql.yml
@@ -19,7 +19,7 @@ servers:
 info:
   title: lT Nest Server
   description: Modern, fast, powerful Node.js web framework in TypeScript based on Nest with a GraphQL API and a connection to MongoDB (or other databases).
-  version: 11.31.0
+  version: 11.31.1
   contact:
     name: lenne.Tech GmbH
     url: https://lenne.tech

--- a/spectaql.yml
+++ b/spectaql.yml
@@ -19,7 +19,7 @@ servers:
 info:
   title: lT Nest Server
   description: Modern, fast, powerful Node.js web framework in TypeScript based on Nest with a GraphQL API and a connection to MongoDB (or other databases).
-  version: 11.30.0
+  version: 11.31.0
   contact:
     name: lenne.Tech GmbH
     url: https://lenne.tech

--- a/src/core/modules/migrate/README.md
+++ b/src/core/modules/migrate/README.md
@@ -432,6 +432,62 @@ The `migrate` command comes from `@lenne.tech/nest-server` - no external package
 
 See the [Migration Guide](./MIGRATION_FROM_NODEPIT.md) for detailed migration instructions from @nodepit.
 
+## Migration Identity & Strict Mode
+
+### Extension-agnostic identity (safe ts-node → compiled-JS transition)
+
+A migration's identity is its timestamped file stem **without** the `.ts`/`.js` extension
+(`migrationId('1699-foo.ts') === migrationId('1699-foo.js') === '1699-foo'`). `up`, `down`,
+and `list`/`status` all compare identities, not raw filenames.
+
+This makes the recommended production setup — running compiled `.js` migrations in the image
+while the state was recorded under `.ts` names via ts-node — safe: already-applied migrations
+are **not** re-run after the switch, and no state rewrite is needed. If both `foo.ts` and
+`foo.js` are present in the migrations directory (e.g. an overlapping `outDir`), they count
+as ONE migration: only the `.js` file is loaded and executed, and a warning is emitted.
+
+Note: identity normalization applies to the `MigrationRunner`/CLI path only. The legacy
+`synchronizedUp()` helper drives the external `migrate` package's own state handling and
+keeps raw-filename identity.
+
+### Missing migration files & strict mode
+
+Old, already-applied migration files can be deleted (they live in git and can be restored).
+By default the runner **tolerates** a recorded migration whose file is gone:
+
+- `migrate up` warns (`[migrate] N recorded migration file(s) missing — tolerated`) and continues, so the server still boots.
+- `migrate list` marks the entry with `(file missing)`.
+- `migrate down` **always fails hard** on a missing rollback file — independent of strict mode. Rollback is an explicit operator action, never a boot path; exiting 0 without rolling anything back would mislead scripts. Restore the file from git, then retry.
+
+Strict mode turns the tolerated drift into a hard error (`up` throws, `list` exits non-zero).
+Enable it via any of:
+
+| Activation path                              | Scope                                                                            |
+| -------------------------------------------- | -------------------------------------------------------------------------------- |
+| `--strict` CLI flag                          | single invocation                                                                |
+| `NSC__MIGRATE__STRICT=1\|true\|yes` env var  | CLI **and** programmatic runners (resolved in the `MigrationRunner` constructor) |
+| `new MigrationRunner({ strict: true, ... })` | programmatic                                                                     |
+
+**Recommended for production images:** set `NSC__MIGRATE__STRICT=true` in the container
+environment. In an immutable image, a recorded-but-missing migration file can only mean a
+broken build (empty/miscopied `migrations/` directory) or a state-store mismatch (wrong
+database) — both are conditions where refusing to boot is correct.
+
+### Programmatic usage (MigrationRunner)
+
+```typescript
+import { MigrationRunner, MongoStateStore } from '@lenne.tech/nest-server';
+
+const runner = new MigrationRunner({
+  migrationsDirectory: './migrations',
+  stateStore: new MongoStateStore(process.env.NSC__MONGOOSE__URI),
+  strict: true, // optional; defaults to NSC__MIGRATE__STRICT, else false
+});
+
+await runner.up();
+const { completed, missing, pending } = await runner.status();
+```
+
 ## Project Integration
 
 The migration utilities are designed to minimize boilerplate in your projects. Instead of copying multiple utility files, you can:

--- a/src/core/modules/migrate/cli/migrate-cli.ts
+++ b/src/core/modules/migrate/cli/migrate-cli.ts
@@ -17,13 +17,14 @@
  *   --store, -s            Path to state store module
  *   --compiler, -c         Compiler to use (e.g., ts:./path/to/ts-compiler.js)
  *   --template-file, -t    Template file for creating migrations
- *   --strict               Fail if a recorded migration's file is missing (default: off / tolerate)
+ *   --strict               Fail if a recorded migration's file is missing (default: off / tolerate).
+ *                          Applies to up/list; down always fails hard on a missing rollback file.
  */
 
 import * as fs from 'fs';
 import * as path from 'path';
 
-import { MigrationRunner } from '../migration-runner';
+import { MigrationRunner, parseStrictEnv } from '../migration-runner';
 import { MongoStateStore } from '../mongo-state-store';
 
 interface CliOptions {
@@ -96,6 +97,7 @@ async function listMigrations(options: CliOptions) {
   });
 
   const status = await runner.status();
+  const missing = new Set(status.missing);
 
   console.log('\nMigration Status:');
   console.log('=================\n');
@@ -103,7 +105,7 @@ async function listMigrations(options: CliOptions) {
   if (status.completed.length > 0) {
     console.log('Completed:');
     status.completed.forEach((name) => {
-      console.log(`  ✓ ${name}`);
+      console.log(`  ✓ ${name}${missing.has(name) ? '  (file missing)' : ''}`);
     });
     console.log('');
   }
@@ -118,6 +120,14 @@ async function listMigrations(options: CliOptions) {
 
   if (status.completed.length === 0 && status.pending.length === 0) {
     console.log('No migrations found\n');
+  }
+
+  // In strict mode, integrity drift is an error also on the inspection surface —
+  // exit non-zero (via main's error handler) instead of hiding it in the listing.
+  if (options.strict && status.missing.length > 0) {
+    throw new Error(
+      `Strict mode: ${status.missing.length} recorded migration file(s) missing: ${status.missing.join(', ')}`,
+    );
   }
 }
 
@@ -203,7 +213,7 @@ function parseArgs(): { command: string; name?: string; options: CliOptions } {
     migrationsDir: './migrations',
     // Off by default: a recorded migration whose file was deleted is tolerated so the
     // server still starts. Enable per-run via `--strict` or globally via NSC__MIGRATE__STRICT.
-    strict: ['1', 'true', 'yes'].includes((process.env.NSC__MIGRATE__STRICT ?? '').toLowerCase()),
+    strict: parseStrictEnv(),
   };
 
   // Check if second arg is a name (not a flag)
@@ -302,7 +312,8 @@ Options:
   --store, -s <path>                 Path to state store module
   --compiler, -c <compiler>          Compiler to use (e.g., ts:./path/to/ts-compiler.js)
   --template-file, -t <path>         Template file for creating migrations
-  --strict                           Fail if a recorded migration's file is missing (default: off / tolerate)
+  --strict                           Fail if a recorded migration's file is missing (default: off / tolerate).
+                                     Applies to up/list; down always fails hard on a missing rollback file.
 
 Examples:
   migrate create add-user-email
@@ -313,7 +324,7 @@ Examples:
 
 Environment Variables:
   NODE_ENV                           Set environment (e.g., development, production)
-  NSC__MIGRATE__STRICT               true → fail on a missing recorded migration file (default: tolerate)
+  NSC__MIGRATE__STRICT               1|true|yes → fail on a missing recorded migration file (default: tolerate)
 `);
 }
 
@@ -325,4 +336,5 @@ if (require.main === module) {
   });
 }
 
-export { main };
+// parseArgs is exported for unit testing only (same pattern as resolveCliPath in bin/migrate.js)
+export { main, parseArgs };

--- a/src/core/modules/migrate/cli/migrate-cli.ts
+++ b/src/core/modules/migrate/cli/migrate-cli.ts
@@ -17,6 +17,7 @@
  *   --store, -s            Path to state store module
  *   --compiler, -c         Compiler to use (e.g., ts:./path/to/ts-compiler.js)
  *   --template-file, -t    Template file for creating migrations
+ *   --strict               Fail if a recorded migration's file is missing (default: off / tolerate)
  */
 
 import * as fs from 'fs';
@@ -29,6 +30,7 @@ interface CliOptions {
   compiler?: string;
   migrationsDir: string;
   store?: string;
+  strict?: boolean;
   templateFile?: string;
 }
 
@@ -90,6 +92,7 @@ async function listMigrations(options: CliOptions) {
   const runner = new MigrationRunner({
     migrationsDirectory: path.resolve(process.cwd(), options.migrationsDir),
     stateStore,
+    strict: options.strict,
   });
 
   const status = await runner.status();
@@ -198,6 +201,9 @@ function parseArgs(): { command: string; name?: string; options: CliOptions } {
   let name: string | undefined;
   const options: CliOptions = {
     migrationsDir: './migrations',
+    // Off by default: a recorded migration whose file was deleted is tolerated so the
+    // server still starts. Enable per-run via `--strict` or globally via NSC__MIGRATE__STRICT.
+    strict: ['1', 'true', 'yes'].includes((process.env.NSC__MIGRATE__STRICT ?? '').toLowerCase()),
   };
 
   // Check if second arg is a name (not a flag)
@@ -217,6 +223,8 @@ function parseArgs(): { command: string; name?: string; options: CliOptions } {
       options.compiler = args[++i];
     } else if (arg === '--template-file' || arg === '-t') {
       options.templateFile = args[++i];
+    } else if (arg === '--strict') {
+      options.strict = true;
     }
   }
 
@@ -254,6 +262,7 @@ async function runDown(options: CliOptions) {
   const runner = new MigrationRunner({
     migrationsDirectory: path.resolve(process.cwd(), options.migrationsDir),
     stateStore,
+    strict: options.strict,
   });
 
   await runner.down();
@@ -269,6 +278,7 @@ async function runUp(options: CliOptions) {
   const runner = new MigrationRunner({
     migrationsDirectory: path.resolve(process.cwd(), options.migrationsDir),
     stateStore,
+    strict: options.strict,
   });
 
   await runner.up();
@@ -292,6 +302,7 @@ Options:
   --store, -s <path>                 Path to state store module
   --compiler, -c <compiler>          Compiler to use (e.g., ts:./path/to/ts-compiler.js)
   --template-file, -t <path>         Template file for creating migrations
+  --strict                           Fail if a recorded migration's file is missing (default: off / tolerate)
 
 Examples:
   migrate create add-user-email
@@ -302,6 +313,7 @@ Examples:
 
 Environment Variables:
   NODE_ENV                           Set environment (e.g., development, production)
+  NSC__MIGRATE__STRICT               true → fail on a missing recorded migration file (default: tolerate)
 `);
 }
 

--- a/src/core/modules/migrate/migration-runner.ts
+++ b/src/core/modules/migrate/migration-runner.ts
@@ -34,6 +34,20 @@ export interface MigrationFile {
 export const DEFAULT_MIGRATION_FILE_PATTERN = /(?:(?<!\.d)\.ts|\.js)$/;
 
 /**
+ * Migration identity = the timestamped file stem WITHOUT its `.ts`/`.js` extension.
+ *
+ * A migration keeps its identity when a project switches its production image from
+ * ts-node (`1699-foo.ts`) to compiled JavaScript (`1699-foo.js`) — the recommended
+ * prod setup, since the image prunes ts-node. Comparing raw filenames would make
+ * every compiled `.js` migration look "pending" against a state recorded under `.ts`
+ * names and re-run already-applied migrations (data corruption on existing DBs).
+ * Normalising both sides makes the transition safe with no state rewrite.
+ */
+export function migrationId(title: string): string {
+  return title.replace(/\.(ts|js)$/, '');
+}
+
+/**
  * Migration runner configuration
  */
 export interface MigrationRunnerOptions {
@@ -43,6 +57,16 @@ export interface MigrationRunnerOptions {
   pattern?: RegExp;
   /** State store for tracking migrations */
   stateStore: MongoStateStore;
+  /**
+   * Fail hard when a migration recorded in the state has no file on disk.
+   *
+   * Default `false` (tolerate): recorded migrations whose files were deleted are
+   * ignored — `up` skips them (with a warning) and the server still starts. Migrations
+   * are tracked in git and can be restored if a rollback is ever needed, so old
+   * migration files can be pruned without blocking boot. Set `true` to enforce
+   * state/disk integrity (missing file → error).
+   */
+  strict?: boolean;
 }
 
 /**
@@ -121,9 +145,24 @@ export class MigrationRunner {
 
     const allMigrations = await this.loadMigrationFiles();
     const state = await this.options.stateStore.loadAsync();
-    const completedMigrations = (state.migrations || []).map((m) => m.title);
+    const recorded = state.migrations || [];
+    const presentIds = new Set(allMigrations.map((m) => migrationId(m.title)));
 
-    const pendingMigrations = allMigrations.filter((m) => !completedMigrations.includes(m.title));
+    // Recorded migrations whose file is gone. Tolerated by default (git-tracked and
+    // restorable); in strict mode this is a hard error so integrity drift is caught.
+    const missing = recorded.filter((m) => !presentIds.has(migrationId(m.title)));
+    if (missing.length > 0) {
+      const list = missing.map((m) => m.title).join(', ');
+      if (this.options.strict) {
+        throw new Error(`Strict mode: ${missing.length} recorded migration file(s) missing: ${list}`);
+      }
+      console.warn(
+        `[migrate] ${missing.length} recorded migration file(s) missing — tolerated (strict=false): ${list}`,
+      );
+    }
+
+    const completedIds = new Set(recorded.map((m) => migrationId(m.title)));
+    const pendingMigrations = allMigrations.filter((m) => !completedIds.has(migrationId(m.title)));
 
     if (pendingMigrations.length === 0) {
       console.log('No pending migrations');
@@ -181,10 +220,16 @@ export class MigrationRunner {
 
     const lastMigration = completedMigrations[completedMigrations.length - 1];
     const allMigrations = await this.loadMigrationFiles();
-    const migrationToRollback = allMigrations.find((m) => m.title === lastMigration.title);
+    const migrationToRollback = allMigrations.find((m) => migrationId(m.title) === migrationId(lastMigration.title));
 
     if (!migrationToRollback) {
-      throw new Error(`Migration file not found: ${lastMigration.title}`);
+      if (this.options.strict) {
+        throw new Error(`Migration file not found: ${lastMigration.title}`);
+      }
+      console.warn(
+        `[migrate] last recorded migration "${lastMigration.title}" has no file — cannot roll back (strict=false); leaving state unchanged.`,
+      );
+      return;
     }
 
     if (!migrationToRollback.down) {
@@ -224,10 +269,11 @@ export class MigrationRunner {
     const allMigrations = await this.loadMigrationFiles();
     const state = await this.options.stateStore.loadAsync();
     const completedMigrations = (state.migrations || []).map((m) => m.title);
+    const completedIds = new Set(completedMigrations.map(migrationId));
 
     return {
       completed: completedMigrations,
-      pending: allMigrations.filter((m) => !completedMigrations.includes(m.title)).map((m) => m.title),
+      pending: allMigrations.filter((m) => !completedIds.has(migrationId(m.title))).map((m) => m.title),
     };
   }
 

--- a/src/core/modules/migrate/migration-runner.ts
+++ b/src/core/modules/migrate/migration-runner.ts
@@ -34,6 +34,12 @@ export interface MigrationFile {
 export const DEFAULT_MIGRATION_FILE_PATTERN = /(?:(?<!\.d)\.ts|\.js)$/;
 
 /**
+ * Matches the trailing `.ts`/`.js` extension stripped by {@link migrationId}.
+ * Hoisted to module level so `migrationId` allocates no per-call RegExp wrapper.
+ */
+const MIGRATION_EXTENSION_PATTERN = /\.(ts|js)$/;
+
+/**
  * Migration identity = the timestamped file stem WITHOUT its `.ts`/`.js` extension.
  *
  * A migration keeps its identity when a project switches its production image from
@@ -42,9 +48,42 @@ export const DEFAULT_MIGRATION_FILE_PATTERN = /(?:(?<!\.d)\.ts|\.js)$/;
  * every compiled `.js` migration look "pending" against a state recorded under `.ts`
  * names and re-run already-applied migrations (data corruption on existing DBs).
  * Normalising both sides makes the transition safe with no state rewrite.
+ *
+ * @param title Migration title, usually the filename (e.g. `1699000000000-foo.ts`)
+ * @returns The extension-agnostic identity (e.g. `1699000000000-foo`)
+ * @example
+ * migrationId('1699000000000-foo.ts'); // '1699000000000-foo'
+ * migrationId('1699000000000-foo.js'); // '1699000000000-foo'
+ * migrationId('1699000000000-foo');    // '1699000000000-foo' (already extensionless)
  */
 export function migrationId(title: string): string {
-  return title.replace(/\.(ts|js)$/, '');
+  return title.replace(MIGRATION_EXTENSION_PATTERN, '');
+}
+
+/**
+ * Parse the `NSC__MIGRATE__STRICT` environment variable into a boolean.
+ *
+ * Truthy values: `1`, `true`, `yes` (case-insensitive, surrounding whitespace ignored —
+ * a real risk with Docker/compose env files). Every other value means `false` (tolerate,
+ * the safe default); non-empty unrecognized values additionally emit a warning so a typo
+ * like `NSC__MIGRATE__STRICT=on` does not silently disable the control the operator
+ * intended to enable.
+ *
+ * Shared by the CLI (`migrate-cli.ts`) and the {@link MigrationRunner} constructor, so
+ * the env var behaves identically for CLI and programmatic runners.
+ */
+export function parseStrictEnv(value: string | undefined = process.env.NSC__MIGRATE__STRICT): boolean {
+  if (value === undefined) {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 'yes'].includes(normalized)) {
+    return true;
+  }
+  if (normalized !== '' && !['0', 'false', 'no'].includes(normalized)) {
+    console.warn(`[migrate] Unrecognized NSC__MIGRATE__STRICT value "${value}" — treating as false (tolerate).`);
+  }
+  return false;
 }
 
 /**
@@ -60,11 +99,18 @@ export interface MigrationRunnerOptions {
   /**
    * Fail hard when a migration recorded in the state has no file on disk.
    *
-   * Default `false` (tolerate): recorded migrations whose files were deleted are
-   * ignored — `up` skips them (with a warning) and the server still starts. Migrations
-   * are tracked in git and can be restored if a rollback is ever needed, so old
+   * Default: resolved from the `NSC__MIGRATE__STRICT` environment variable (see
+   * {@link parseStrictEnv}), falling back to `false` (tolerate) — recorded migrations
+   * whose files were deleted are ignored: `up()` skips them (with a warning) and the
+   * server still starts. Migrations are tracked in git and can be restored, so old
    * migration files can be pruned without blocking boot. Set `true` to enforce
-   * state/disk integrity (missing file → error).
+   * state/disk integrity (missing file → error in `up()` and `migrate list`).
+   *
+   * Applies to `up()` and `status()`/`migrate list` only — `down()` ALWAYS fails hard
+   * on a missing rollback file, because rollback is an explicit operator action and
+   * never a boot path (an exit 0 with no rollback performed would mislead scripts).
+   *
+   * @see `--strict` CLI flag and `NSC__MIGRATE__STRICT` env var in `cli/migrate-cli.ts`
    */
   strict?: boolean;
 }
@@ -96,12 +142,21 @@ export class MigrationRunner {
   private pattern: RegExp;
 
   constructor(options: MigrationRunnerOptions) {
-    this.options = options;
+    // Resolve the strict default from the environment so NSC__MIGRATE__STRICT works
+    // identically for programmatic runners and the CLI (which parses it itself).
+    this.options = { ...options, strict: options.strict ?? parseStrictEnv() };
     this.pattern = options.pattern || DEFAULT_MIGRATION_FILE_PATTERN;
   }
 
   /**
    * Load all migration files from the migrations directory
+   *
+   * Files are deduplicated by {@link migrationId}: when both `foo.ts` and `foo.js`
+   * are present (overlapping `outDir`, source + build output copied into one image),
+   * they are ONE migration — loading both would execute it twice in a single `up()`
+   * run (the exact double-execution the identity concept exists to prevent). The
+   * `.js` file wins deterministically (`.js` sorts before `.ts`), matching the
+   * compiled-production intent; the duplicate is skipped with a warning.
    */
   private async loadMigrationFiles(): Promise<MigrationFile[]> {
     const files = fs
@@ -110,8 +165,17 @@ export class MigrationRunner {
       .sort(); // Sort alphabetically (timestamp-based filenames will be in order)
 
     const migrations: MigrationFile[] = [];
+    const seenIds = new Set<string>();
 
     for (const file of files) {
+      const id = migrationId(file);
+      if (seenIds.has(id)) {
+        console.warn(
+          `[migrate] duplicate files for migration "${id}" — skipping ${file} (a same-named file was already loaded)`,
+        );
+        continue;
+      }
+
       const filePath = path.join(this.options.migrationsDirectory, file);
 
       const module = require(filePath);
@@ -125,6 +189,7 @@ export class MigrationRunner {
       const timestampMatch = file.match(/^(\d+)-/);
       const timestamp = timestampMatch ? parseInt(timestampMatch[1], 10) : Date.now();
 
+      seenIds.add(id);
       migrations.push({
         down: module.down,
         filePath,
@@ -220,16 +285,14 @@ export class MigrationRunner {
 
     const lastMigration = completedMigrations[completedMigrations.length - 1];
     const allMigrations = await this.loadMigrationFiles();
-    const migrationToRollback = allMigrations.find((m) => migrationId(m.title) === migrationId(lastMigration.title));
+    const rollbackId = migrationId(lastMigration.title);
+    const migrationToRollback = allMigrations.find((m) => migrationId(m.title) === rollbackId);
 
     if (!migrationToRollback) {
-      if (this.options.strict) {
-        throw new Error(`Migration file not found: ${lastMigration.title}`);
-      }
-      console.warn(
-        `[migrate] last recorded migration "${lastMigration.title}" has no file — cannot roll back (strict=false); leaving state unchanged.`,
-      );
-      return;
+      // Always a hard error, independent of `strict`: down() is an explicit operator
+      // action and never a boot path — the boot-tolerance rationale does not apply,
+      // and an exit 0 with no rollback performed would mislead scripted rollbacks.
+      throw new Error(`Migration file not found: ${lastMigration.title} — restore the file from git to roll back.`);
     }
 
     if (!migrationToRollback.down) {
@@ -261,18 +324,26 @@ export class MigrationRunner {
 
   /**
    * Get migration status
+   *
+   * `missing` lists recorded migrations whose file is gone from disk (identity-based,
+   * so a `.ts`-recorded migration with a compiled `.js` on disk is NOT missing) — the
+   * same integrity drift `up()` warns about, surfaced here so `migrate list` can show
+   * it before a deploy or file pruning.
    */
   async status(): Promise<{
     completed: string[];
+    missing: string[];
     pending: string[];
   }> {
     const allMigrations = await this.loadMigrationFiles();
     const state = await this.options.stateStore.loadAsync();
     const completedMigrations = (state.migrations || []).map((m) => m.title);
     const completedIds = new Set(completedMigrations.map(migrationId));
+    const presentIds = new Set(allMigrations.map((m) => migrationId(m.title)));
 
     return {
       completed: completedMigrations,
+      missing: completedMigrations.filter((title) => !presentIds.has(migrationId(title))),
       pending: allMigrations.filter((m) => !completedIds.has(migrationId(m.title))).map((m) => m.title),
     };
   }

--- a/tests/unit/migrate-cli-strict-parsing.spec.ts
+++ b/tests/unit/migrate-cli-strict-parsing.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit Tests: migrate CLI argument parsing — the --strict flag and its
+ * NSC__MIGRATE__STRICT environment default.
+ *
+ * parseArgs is exported for testing only (same pattern as resolveCliPath in
+ * bin/migrate.js): the CLI runs main() solely behind a require.main guard, so
+ * importing the module here is side-effect-free.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { parseArgs } from '../../src/core/modules/migrate/cli/migrate-cli';
+
+const savedArgv = process.argv;
+const savedStrictEnv = process.env.NSC__MIGRATE__STRICT;
+
+function withArgs(...args: string[]): void {
+  process.argv = ['node', 'migrate', ...args];
+}
+
+beforeEach(() => {
+  delete process.env.NSC__MIGRATE__STRICT;
+});
+
+afterEach(() => {
+  process.argv = savedArgv;
+  if (savedStrictEnv === undefined) {
+    delete process.env.NSC__MIGRATE__STRICT;
+  } else {
+    process.env.NSC__MIGRATE__STRICT = savedStrictEnv;
+  }
+});
+
+describe('parseArgs — strict resolution', () => {
+  it('defaults to strict=false when neither --strict nor NSC__MIGRATE__STRICT is set', () => {
+    withArgs('up', '--store', './migrate.js');
+
+    const { command, options } = parseArgs();
+
+    expect(command).toBe('up');
+    expect(options.strict).toBe(false);
+    expect(options.migrationsDir).toBe('./migrations');
+  });
+
+  it('enables strict via the --strict flag', () => {
+    withArgs('up', '--strict');
+
+    expect(parseArgs().options.strict).toBe(true);
+  });
+
+  it.each(['1', 'true', 'yes', 'TRUE'])('enables strict via NSC__MIGRATE__STRICT=%s', (value) => {
+    process.env.NSC__MIGRATE__STRICT = value;
+    withArgs('up');
+
+    expect(parseArgs().options.strict).toBe(true);
+  });
+
+  it.each(['', '0', 'false', 'no'])('stays tolerant for NSC__MIGRATE__STRICT=%j', (value) => {
+    process.env.NSC__MIGRATE__STRICT = value;
+    withArgs('up');
+
+    expect(parseArgs().options.strict).toBe(false);
+  });
+
+  it('lets --strict win over a falsy environment value', () => {
+    process.env.NSC__MIGRATE__STRICT = '0';
+    withArgs('down', '--strict');
+
+    const { command, options } = parseArgs();
+
+    expect(command).toBe('down');
+    expect(options.strict).toBe(true);
+  });
+
+  it('keeps parsing the surrounding options untouched', () => {
+    withArgs('list', '--strict', '--migrations-dir', './db/migrations', '--store', './store.js');
+
+    const { command, name, options } = parseArgs();
+
+    expect(command).toBe('list');
+    expect(name).toBeUndefined();
+    expect(options).toEqual({
+      migrationsDir: './db/migrations',
+      store: './store.js',
+      strict: true,
+    });
+  });
+});

--- a/tests/unit/migration-runner-identity.spec.ts
+++ b/tests/unit/migration-runner-identity.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit Tests: MigrationRunner identity + missing-file tolerance
+ *
+ * Two safety properties for the ts-node → compiled-JS production transition:
+ *
+ *  1. Extension-agnostic identity — a migration recorded under its `.ts` name (how it
+ *     ran via ts-node) must NOT be re-run once the prod image ships the compiled `.js`.
+ *     Keying state by raw filename would treat `foo.js` as a new migration against a
+ *     `foo.ts` state and re-run already-applied, non-idempotent migrations (data loss).
+ *
+ *  2. Missing files are tolerated by default — deleting an old, already-applied
+ *     migration file (they live in git and can be restored) must not crash the boot.
+ *     `strict` opts back into hard integrity enforcement.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { MongoStateStore } from '../../src/core/modules/migrate/mongo-state-store';
+
+import { MigrationRunner, migrationId } from '../../src/core/modules/migrate/migration-runner';
+
+/** State store stub: serves a fixed recorded set, swallows saves. */
+function fakeStore(recorded: { title: string }[]): MongoStateStore {
+  return {
+    loadAsync: async () => ({ migrations: recorded }),
+    saveAsync: async () => undefined,
+  } as unknown as MongoStateStore;
+}
+
+describe('migrationId', () => {
+  it('strips the .ts / .js extension so identity survives the transpile → compile switch', () => {
+    expect(migrationId('1699000000000-foo.ts')).toBe('1699000000000-foo');
+    expect(migrationId('1699000000000-foo.js')).toBe('1699000000000-foo');
+    expect(migrationId('1699000000000-foo')).toBe('1699000000000-foo');
+  });
+});
+
+describe('MigrationRunner', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'migrate-runner-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { force: true, recursive: true });
+  });
+
+  it('does not mark a compiled .js migration pending when it is recorded under its .ts name', async () => {
+    fs.writeFileSync(path.join(dir, '1699000000000-foo.js'), 'module.exports.up = async () => {};\n');
+    const runner = new MigrationRunner({
+      migrationsDirectory: dir,
+      stateStore: fakeStore([{ title: '1699000000000-foo.ts' }]),
+    });
+
+    const status = await runner.status();
+
+    expect(status.pending).toEqual([]);
+    expect(status.completed).toEqual(['1699000000000-foo.ts']);
+  });
+
+  it('up() tolerates a recorded migration whose file was deleted (default, strict=false)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    // Empty migrations dir → the recorded migration's file is gone.
+    const runner = new MigrationRunner({
+      migrationsDirectory: dir,
+      stateStore: fakeStore([{ title: '1699000000000-deleted.ts' }]),
+    });
+
+    await expect(runner.up()).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('missing'));
+    warn.mockRestore();
+  });
+
+  it('up() fails on a missing migration file when strict=true', async () => {
+    const runner = new MigrationRunner({
+      migrationsDirectory: dir,
+      stateStore: fakeStore([{ title: '1699000000000-deleted.ts' }]),
+      strict: true,
+    });
+
+    await expect(runner.up()).rejects.toThrow(/missing/i);
+  });
+});

--- a/tests/unit/migration-runner-identity.spec.ts
+++ b/tests/unit/migration-runner-identity.spec.ts
@@ -1,40 +1,112 @@
 /**
  * Unit Tests: MigrationRunner identity + missing-file tolerance
  *
- * Two safety properties for the ts-node → compiled-JS production transition:
+ * Safety properties for the ts-node → compiled-JS production transition:
  *
  *  1. Extension-agnostic identity — a migration recorded under its `.ts` name (how it
  *     ran via ts-node) must NOT be re-run once the prod image ships the compiled `.js`.
  *     Keying state by raw filename would treat `foo.js` as a new migration against a
  *     `foo.ts` state and re-run already-applied, non-idempotent migrations (data loss).
+ *     Co-present `foo.ts` + `foo.js` are ONE migration — only one file is loaded and
+ *     executed per `up()` run (deduplicated by identity, `.js` wins).
  *
- *  2. Missing files are tolerated by default — deleting an old, already-applied
+ *  2. Missing files are tolerated by default in `up()` — deleting an old, already-applied
  *     migration file (they live in git and can be restored) must not crash the boot.
- *     `strict` opts back into hard integrity enforcement.
+ *     `strict` (option or NSC__MIGRATE__STRICT) opts back into hard integrity
+ *     enforcement. `down()` ALWAYS fails hard on a missing rollback file — rollback is
+ *     an explicit operator action, never a boot path, and an exit 0 with no rollback
+ *     performed would mislead scripted rollbacks.
  */
 
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { MongoStateStore } from '../../src/core/modules/migrate/mongo-state-store';
+import type { MigrationSet, MongoStateStore } from '../../src/core/modules/migrate/mongo-state-store';
 
-import { MigrationRunner, migrationId } from '../../src/core/modules/migrate/migration-runner';
+import { MigrationRunner, migrationId, parseStrictEnv } from '../../src/core/modules/migrate/migration-runner';
 
-/** State store stub: serves a fixed recorded set, swallows saves. */
-function fakeStore(recorded: { title: string }[]): MongoStateStore {
-  return {
-    loadAsync: async () => ({ migrations: recorded }),
-    saveAsync: async () => undefined,
-  } as unknown as MongoStateStore;
+/**
+ * State store stub: serves a FRESH copy of the recorded set per load (like a real DB
+ * read) and captures every save, so tests can assert state changes — or their absence.
+ */
+function fakeStore(recorded: { timestamp?: number; title: string }[]): {
+  saves: MigrationSet[];
+  store: MongoStateStore;
+} {
+  const saves: MigrationSet[] = [];
+  const store = {
+    loadAsync: async () => ({ migrations: recorded.map((m) => ({ ...m })), up: () => {} }),
+    saveAsync: async (set) => {
+      saves.push(set);
+    },
+  } satisfies Pick<MongoStateStore, 'loadAsync' | 'saveAsync'> as unknown as MongoStateStore;
+  return { saves, store };
 }
+
+/** Write a CJS migration fixture whose up/down append a marker line when executed. */
+function writeMigration(dir: string, fileName: string, options?: { downMarker?: string; upMarker?: string }): void {
+  const up = options?.upMarker
+    ? `require('fs').appendFileSync(${JSON.stringify(options.upMarker)}, 'up\\n');`
+    : '';
+  const down = options?.downMarker
+    ? `module.exports.down = async () => { require('fs').appendFileSync(${JSON.stringify(options.downMarker)}, 'down\\n'); };\n`
+    : '';
+  fs.writeFileSync(path.join(dir, fileName), `module.exports.up = async () => { ${up} };\n${down}`);
+}
+
+// The MigrationRunner constructor resolves its strict default from NSC__MIGRATE__STRICT —
+// isolate the suite from whatever the invoking shell has set.
+const savedStrictEnv = process.env.NSC__MIGRATE__STRICT;
+beforeAll(() => {
+  delete process.env.NSC__MIGRATE__STRICT;
+});
+afterAll(() => {
+  if (savedStrictEnv === undefined) {
+    delete process.env.NSC__MIGRATE__STRICT;
+  } else {
+    process.env.NSC__MIGRATE__STRICT = savedStrictEnv;
+  }
+});
+
+// A failing assertion between spyOn and mockRestore must not leak a silenced console
+// into the remaining tests of this fork (vitest.config.ts sets no restoreMocks).
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('migrationId', () => {
   it('strips the .ts / .js extension so identity survives the transpile → compile switch', () => {
     expect(migrationId('1699000000000-foo.ts')).toBe('1699000000000-foo');
     expect(migrationId('1699000000000-foo.js')).toBe('1699000000000-foo');
     expect(migrationId('1699000000000-foo')).toBe('1699000000000-foo');
+  });
+});
+
+describe('parseStrictEnv', () => {
+  it('accepts 1/true/yes case-insensitively and ignores surrounding whitespace', () => {
+    expect(parseStrictEnv('1')).toBe(true);
+    expect(parseStrictEnv('true')).toBe(true);
+    expect(parseStrictEnv('TRUE')).toBe(true);
+    expect(parseStrictEnv('yes')).toBe(true);
+    expect(parseStrictEnv(' true ')).toBe(true);
+  });
+
+  it('treats unset, empty, and recognized falsy values as false without warning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    expect(parseStrictEnv(undefined)).toBe(false);
+    expect(parseStrictEnv('')).toBe(false);
+    expect(parseStrictEnv('0')).toBe(false);
+    expect(parseStrictEnv('false')).toBe(false);
+    expect(parseStrictEnv('no')).toBe(false);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('warns on non-empty unrecognized values and falls back to false (tolerate)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    expect(parseStrictEnv('on')).toBe(false);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Unrecognized NSC__MIGRATE__STRICT value "on"'));
   });
 });
 
@@ -49,39 +121,112 @@ describe('MigrationRunner', () => {
     fs.rmSync(dir, { force: true, recursive: true });
   });
 
-  it('does not mark a compiled .js migration pending when it is recorded under its .ts name', async () => {
-    fs.writeFileSync(path.join(dir, '1699000000000-foo.js'), 'module.exports.up = async () => {};\n');
-    const runner = new MigrationRunner({
-      migrationsDirectory: dir,
-      stateStore: fakeStore([{ title: '1699000000000-foo.ts' }]),
+  describe('status', () => {
+    it('does not mark a compiled .js migration pending (or missing) when it is recorded under its .ts name', async () => {
+      writeMigration(dir, '1699000000000-foo.js');
+      const { store } = fakeStore([{ title: '1699000000000-foo.ts' }]);
+      const runner = new MigrationRunner({ migrationsDirectory: dir, stateStore: store });
+
+      const status = await runner.status();
+
+      expect(status.pending).toEqual([]);
+      expect(status.completed).toEqual(['1699000000000-foo.ts']);
+      expect(status.missing).toEqual([]);
     });
 
-    const status = await runner.status();
+    it('lists a recorded migration whose file was deleted in missing (completed keeps it, pending stays empty)', async () => {
+      const { store } = fakeStore([{ title: '1699000000000-deleted.ts' }]);
+      const runner = new MigrationRunner({ migrationsDirectory: dir, stateStore: store });
 
-    expect(status.pending).toEqual([]);
-    expect(status.completed).toEqual(['1699000000000-foo.ts']);
+      const status = await runner.status();
+
+      expect(status.completed).toEqual(['1699000000000-deleted.ts']);
+      expect(status.missing).toEqual(['1699000000000-deleted.ts']);
+      expect(status.pending).toEqual([]);
+    });
   });
 
-  it('up() tolerates a recorded migration whose file was deleted (default, strict=false)', async () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-    // Empty migrations dir → the recorded migration's file is gone.
-    const runner = new MigrationRunner({
-      migrationsDirectory: dir,
-      stateStore: fakeStore([{ title: '1699000000000-deleted.ts' }]),
+  describe('up', () => {
+    it('does not re-run a compiled .js migration recorded under its .ts name', async () => {
+      const marker = path.join(dir, 'up-executed.marker');
+      writeMigration(dir, '1699000000000-foo.js', { upMarker: marker });
+      const { saves, store } = fakeStore([{ title: '1699000000000-foo.ts' }]);
+      const runner = new MigrationRunner({ migrationsDirectory: dir, stateStore: store });
+
+      await expect(runner.up()).resolves.toBeUndefined();
+
+      expect(fs.existsSync(marker)).toBe(false); // the migration body never ran
+      expect(saves).toEqual([]); // no state written — nothing was pending
     });
 
-    await expect(runner.up()).resolves.toBeUndefined();
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('missing'));
-    warn.mockRestore();
+    it('runs co-present .ts and .js files of one migration exactly once (dedupe by identity, .js wins)', async () => {
+      const marker = path.join(dir, 'run-count.marker');
+      writeMigration(dir, '1699000000000-foo.js', { upMarker: marker });
+      writeMigration(dir, '1699000000000-foo.ts', { upMarker: marker });
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const { saves, store } = fakeStore([]);
+      const runner = new MigrationRunner({ migrationsDirectory: dir, stateStore: store });
+
+      await expect(runner.up()).resolves.toBeUndefined();
+
+      expect(fs.readFileSync(marker, 'utf-8')).toBe('up\n'); // exactly one execution
+      expect(saves).toHaveLength(1);
+      expect(saves[0].migrations.map((m) => m.title)).toEqual(['1699000000000-foo.js']);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('duplicate files for migration "1699000000000-foo"'));
+    });
+
+    it('tolerates a recorded migration whose file was deleted (default, strict=false) and leaves state untouched', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      // Empty migrations dir → the recorded migration's file is gone.
+      const { saves, store } = fakeStore([{ title: '1699000000000-deleted.ts' }]);
+      const runner = new MigrationRunner({ migrationsDirectory: dir, stateStore: store });
+
+      await expect(runner.up()).resolves.toBeUndefined();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '1 recorded migration file(s) missing — tolerated (strict=false): 1699000000000-deleted.ts',
+        ),
+      );
+      expect(saves).toEqual([]); // state untouched
+    });
+
+    it('fails on a missing migration file when strict=true, naming count and file', async () => {
+      const { store } = fakeStore([{ title: '1699000000000-deleted.ts' }]);
+      const runner = new MigrationRunner({ migrationsDirectory: dir, stateStore: store, strict: true });
+
+      await expect(runner.up()).rejects.toThrow(
+        /Strict mode: 1 recorded migration file\(s\) missing: 1699000000000-deleted\.ts/,
+      );
+    });
   });
 
-  it('up() fails on a missing migration file when strict=true', async () => {
-    const runner = new MigrationRunner({
-      migrationsDirectory: dir,
-      stateStore: fakeStore([{ title: '1699000000000-deleted.ts' }]),
-      strict: true,
+  describe('down', () => {
+    it('rolls back a migration recorded under its .ts name via the compiled .js file', async () => {
+      const marker = path.join(dir, 'down-executed.marker');
+      writeMigration(dir, '1699000000000-foo.js', { downMarker: marker });
+      const { saves, store } = fakeStore([{ title: '1699000000000-foo.ts' }]);
+      const runner = new MigrationRunner({ migrationsDirectory: dir, stateStore: store });
+
+      await expect(runner.down()).resolves.toBeUndefined();
+
+      expect(fs.readFileSync(marker, 'utf-8')).toBe('down\n'); // rollback body ran
+      expect(saves).toHaveLength(1);
+      expect(saves[0].migrations).toEqual([]); // popped from state
     });
 
-    await expect(runner.up()).rejects.toThrow(/missing/i);
+    it('always fails hard when the last recorded migration has no file — regardless of strict', async () => {
+      const recorded = [{ title: '1699000000000-deleted.ts' }];
+      const expected = /Migration file not found: 1699000000000-deleted\.ts — restore the file from git/;
+
+      const tolerant = new MigrationRunner({ migrationsDirectory: dir, stateStore: fakeStore(recorded).store });
+      await expect(tolerant.down()).rejects.toThrow(expected);
+
+      const explicitlyTolerant = new MigrationRunner({
+        migrationsDirectory: dir,
+        stateStore: fakeStore(recorded).store,
+        strict: false,
+      });
+      await expect(explicitlyTolerant.down()).rejects.toThrow(expected);
+    });
   });
 });


### PR DESCRIPTION
## What is this?

Non-breaking patch release. Makes the ts-node → compiled-JS production transition safe for the Migrate module and adds an opt-in strict integrity mode for missing migration files.

## Changes

- **Extension-agnostic migration identity**: `up`/`down`/`list` compare migrations by their timestamped stem without the `.ts`/`.js` extension, so a migration recorded under its `.ts` name (ts-node) is not re-run against the compiled `.js` in a production image. No state rewrite needed.
- **Deduplication**: co-present `foo.ts` + `foo.js` now execute exactly once per `up()` run (`.js` wins).
- **Strict mode** (opt-in): `--strict` / `NSC__MIGRATE__STRICT` / `MigrationRunnerOptions.strict` turn a recorded-but-missing migration file into a hard error in `up`/`list`. `down` always fails hard on a missing rollback file.
- **`status()`** gains an additive `missing: string[]`; `migrate list` annotates `(file missing)`.

## Migration

See [migration-guides/11.31.0-to-11.31.1.md](https://github.com/lenneTech/nest-server/blob/develop/migration-guides/11.31.0-to-11.31.1.md). No code changes required for most projects; optionally set `NSC__MIGRATE__STRICT=true` in production images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)