### PR TITLE
11.31.2: list own AI conversations without 403 (REST + GraphQL) + admin all-scope & creator attribution

### DIFF
--- a/FRAMEWORK-API.md
+++ b/FRAMEWORK-API.md
@@ -1,6 +1,6 @@
 # @lenne.tech/nest-server — Framework API Reference
 
-> Auto-generated from source code on 2026-07-19 (v11.31.1)
+> Auto-generated from source code on 2026-07-19 (v11.31.2)
 > File: `FRAMEWORK-API.md` — compact, machine-readable API surface for Claude Code
 
 ## CoreModule.forRoot()

--- a/migration-guides/11.31.1-to-11.31.2.md
+++ b/migration-guides/11.31.1-to-11.31.2.md
@@ -1,0 +1,127 @@
+# Migration Guide: 11.31.1 → 11.31.2
+
+## Overview
+
+| Category | Details |
+|----------|---------|
+| **Breaking Changes** | None (one behavior change for admins — see below) |
+| **New Features** | Admin cross-user conversation listing (`?all=true`), creator attribution (`createdByUser`) |
+| **Bugfixes** | Non-admins can list their own AI conversations again (was HTTP 403 / GraphQL "Access denied") |
+| **Migration Effort** | None for most projects — no code changes required |
+
+---
+
+## Quick Migration
+
+```bash
+# Update package
+pnpm update @lenne.tech/nest-server@11.31.2
+
+# Verify
+pnpm run build && pnpm test
+```
+
+No configuration changes are required. Everything below is automatic (the
+bugfix) or opt-in (the two new features).
+
+---
+
+## What's New in 11.31.2
+
+### 1. Non-admins can list their own AI conversations again (bugfix)
+
+`GET /ai/conversations` and the GraphQL `findAiConversations` query returned
+`403` / "Access denied" for every non-admin user, so their own conversations
+never loaded. The list endpoints passed the per-document roles
+`[ADMIN, S_CREATOR, S_SELF]`, which a LIST operation can never satisfy (there is
+no single object to check ownership against), so non-admins were rejected before
+ownership scoping ran.
+
+Both endpoints now authorize the list with `S_USER` and scope the result to the
+caller via a server-side `createdBy` filter plus the model's `securityCheck`.
+Cross-user isolation is unchanged — a non-admin still only ever sees their own
+conversations. **No action required**; it simply works after the update.
+
+### 2. Admins can opt in to a cross-user view (`?all=true`)
+
+By default every user — **admins included** — now receives only their own
+conversations. An admin can list every user's conversations on demand:
+
+```bash
+# REST
+GET /ai/conversations?all=true
+```
+
+```graphql
+# GraphQL
+query { findAiConversations(all: true) { id title createdBy createdByUser } }
+```
+
+The flag is ignored for non-admins, so it can never widen a regular user's
+scope. Results are ordered newest-first.
+
+### 3. Creator attribution in the admin cross-user view (`createdByUser`)
+
+In the admin cross-user view (`all: true`) each conversation additionally
+carries a resolved `createdByUser` object so the list is attributable to a named
+user:
+
+```jsonc
+{
+  "id": "…",
+  "title": "…",
+  "createdBy": "665f…",                // owner user id (always present)
+  "createdByUser": {                    // only in the admin all-view
+    "id": "665f…",
+    "email": "user@example.com",
+    "firstName": "…",
+    "lastName": "…",
+    "username": "…"
+  }
+}
+```
+
+On a normal own-only fetch `createdByUser` is left unset (the owner is the
+caller, so no lookup is needed).
+
+---
+
+## Behavior Change (admins only)
+
+Before 11.31.2, `GET /ai/conversations` returned **all** users' conversations
+for an admin by default. It now returns the **admin's own** conversations by
+default, matching every other role. If your admin UI relied on the unscoped
+list, request the cross-user view explicitly with `?all=true` (REST) or
+`all: true` (GraphQL). Non-admin behavior is unchanged.
+
+---
+
+## Compatibility Notes
+
+- `getConversation` / `deleteConversation` (single-object operations) are
+  unchanged — they still use `[ADMIN, S_CREATOR, S_SELF]`, which is correct
+  because a single loaded object exists to check ownership against.
+- Projects that extend `CoreAiConversationService` and override its constructor
+  must forward the new `@InjectConnection()` parameter to `super(...)` (used to
+  resolve creators for the admin view). Projects that do not subclass the
+  service are unaffected.
+
+---
+
+## Module Documentation
+
+### AI Module
+
+- **README:** [src/core/modules/ai/README.md](../src/core/modules/ai/README.md)
+- **Integration Checklist:** [src/core/modules/ai/INTEGRATION-CHECKLIST.md](../src/core/modules/ai/INTEGRATION-CHECKLIST.md)
+- **Reference Implementation:** `src/server/modules/ai/`
+- **Key Files:**
+  - `core-ai.controller.ts` / `core-ai.resolver.ts` — list endpoints delegate to the shared service method
+  - `services/core-ai-conversation.service.ts` — `findForCurrentUser()` (shared owner-scoped list + admin all-scope + creator attribution)
+  - `models/core-ai-conversation.model.ts` — `createdByUser` field, ownership `securityCheck`
+
+---
+
+## References
+
+- [nest-server-starter](https://github.com/lenneTech/nest-server-starter) (reference implementation)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lenne.tech/nest-server",
-  "version": "11.31.1",
+  "version": "11.31.2",
   "description": "Modern, fast, powerful Node.js web framework in TypeScript based on Nest with a GraphQL API and a connection to MongoDB (or other databases).",
   "keywords": [
     "node",

--- a/spectaql.yml
+++ b/spectaql.yml
@@ -19,7 +19,7 @@ servers:
 info:
   title: lT Nest Server
   description: Modern, fast, powerful Node.js web framework in TypeScript based on Nest with a GraphQL API and a connection to MongoDB (or other databases).
-  version: 11.31.1
+  version: 11.31.2
   contact:
     name: lenne.Tech GmbH
     url: https://lenne.tech

--- a/src/core/modules/ai/core-ai.controller.ts
+++ b/src/core/modules/ai/core-ai.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Param, Post, Put, Res } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Post, Put, Query, Res } from '@nestjs/common';
 import { Response } from 'express';
 
 import { RESTServiceOptions } from '../../common/decorators/rest-service-options.decorator';
@@ -266,7 +266,9 @@ export class CoreAiController {
   }
 
   /**
-   * Find the current user's AI conversations (admins see all).
+   * Find the current user's AI conversations (own only by default). An admin may
+   * pass `?all=true` to list every user's conversations; each result carries its
+   * `createdBy` owner id for attribution. The flag is ignored for non-admins.
    *
    * The `messages` subdocument array is excluded from the list result — clients
    * fetching the conversation detail via `getConversation` get the full message
@@ -274,13 +276,14 @@ export class CoreAiController {
    */
   @Get('conversations')
   @Roles(RoleEnum.S_USER)
-  async findConversations(@RESTServiceOptions() serviceOptions: ServiceOptions): Promise<CoreAiConversation[]> {
-    const currentUser = serviceOptions?.currentUser;
-    const filterQuery = currentUser?.roles?.includes(RoleEnum.ADMIN) ? {} : { createdBy: currentUser?.id };
-    return this.conversationService.find(
-      { filterQuery },
-      { ...serviceOptions, roles: [RoleEnum.ADMIN, RoleEnum.S_CREATOR, RoleEnum.S_SELF], select: '-messages' },
-    );
+  async findConversations(
+    @RESTServiceOptions() serviceOptions: ServiceOptions,
+    @Query('all') all?: string,
+  ): Promise<CoreAiConversation[]> {
+    // Owner-scoped list shared with the GraphQL resolver — see
+    // CoreAiConversationService.findForCurrentUser for the role/ownership rationale.
+    // Admins default to their own conversations and opt in to the cross-user view via ?all=true.
+    return this.conversationService.findForCurrentUser(serviceOptions, { all: all === 'true' });
   }
 
   /**

--- a/src/core/modules/ai/core-ai.resolver.ts
+++ b/src/core/modules/ai/core-ai.resolver.ts
@@ -270,21 +270,26 @@ export class CoreAiResolver {
   }
 
   /**
-   * Find the current user's AI conversations (admins see all).
+   * Find the current user's AI conversations (own only by default). An admin may
+   * pass `all: true` to list every user's conversations; each result carries its
+   * `createdBy` owner id for attribution. The argument is ignored for non-admins.
    *
    * The `messages` subdocument array is excluded from the list result — clients
    * fetching the conversation detail via `getAiConversation` get the full message
    * history. List payloads stay small even for users with many long conversations.
    */
-  @Query(() => [CoreAiConversation], { description: 'Find AI conversations of the current user' })
+  @Query(() => [CoreAiConversation], {
+    description: "Find AI conversations of the current user (admins may pass all: true to see every user's)",
+  })
   @Roles(RoleEnum.S_USER)
-  async findAiConversations(@GraphQLServiceOptions() serviceOptions: ServiceOptions): Promise<CoreAiConversation[]> {
-    const currentUser = serviceOptions?.currentUser;
-    const filterQuery = currentUser?.roles?.includes(RoleEnum.ADMIN) ? {} : { createdBy: currentUser?.id };
-    return this.conversationService.find(
-      { filterQuery },
-      { ...serviceOptions, roles: [RoleEnum.ADMIN, RoleEnum.S_CREATOR, RoleEnum.S_SELF], select: '-messages' },
-    );
+  async findAiConversations(
+    @GraphQLServiceOptions() serviceOptions: ServiceOptions,
+    @Args('all', { nullable: true, type: () => Boolean }) all?: boolean,
+  ): Promise<CoreAiConversation[]> {
+    // Owner-scoped list shared with the REST controller — see
+    // CoreAiConversationService.findForCurrentUser for the role/ownership rationale.
+    // Admins default to their own conversations and opt in to the cross-user view via all: true.
+    return this.conversationService.findForCurrentUser(serviceOptions, { all: all === true });
   }
 
   /**

--- a/src/core/modules/ai/models/core-ai-conversation.model.ts
+++ b/src/core/modules/ai/models/core-ai-conversation.model.ts
@@ -6,6 +6,7 @@ import { Restricted } from '../../../common/decorators/restricted.decorator';
 import { UnifiedField } from '../../../common/decorators/unified-field.decorator';
 import { RoleEnum } from '../../../common/enums/role.enum';
 import { CorePersistenceModel } from '../../../common/models/core-persistence.model';
+import { JSON } from '../../../common/scalars/json.scalar';
 import { CoreAiMessage } from './core-ai-message.model';
 
 export type AiConversationDocument = CoreAiConversation & Document;
@@ -46,6 +47,22 @@ export class CoreAiConversation extends CorePersistenceModel {
   createdBy?: string = undefined;
 
   /**
+   * Resolved creator identity (`{ id, email, firstName, lastName, username }`),
+   * attached at read time ONLY for an admin's cross-user list view (`all: true`)
+   * so each conversation is attributable to a named user. Not persisted and left
+   * unset on a normal own-only fetch, where the owner is the caller.
+   */
+  @UnifiedField({
+    description:
+      'Resolved creator identity (id, email, name) — set only in the admin cross-user list view, not persisted',
+    gqlType: JSON,
+    isOptional: true,
+    roles: RoleEnum.S_USER,
+    type: () => Object,
+  })
+  createdByUser?: Record<string, any> = undefined;
+
+  /**
    * Conversation messages (appended via $push).
    */
   @UnifiedField({
@@ -76,7 +93,7 @@ export class CoreAiConversation extends CorePersistenceModel {
     if (force) {
       return this;
     }
-    if (user && (user.hasRole?.(RoleEnum.ADMIN) || (this.createdBy && String(this.createdBy) === user.id))) {
+    if (user && (user.hasRole?.(RoleEnum.ADMIN) || (this.createdBy && String(this.createdBy) === String(user.id)))) {
       return this;
     }
     // Hide conversations owned by other users (filtered out of list responses).

--- a/src/core/modules/ai/services/core-ai-conversation.service.ts
+++ b/src/core/modules/ai/services/core-ai-conversation.service.ts
@@ -1,7 +1,9 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { InjectModel } from '@nestjs/mongoose';
-import { Model, Types } from 'mongoose';
+import { InjectConnection, InjectModel } from '@nestjs/mongoose';
+import { Connection, Model, Types } from 'mongoose';
 
+import { RoleEnum } from '../../../common/enums/role.enum';
+import { ServiceOptions } from '../../../common/interfaces/service-options.interface';
 import { CrudService } from '../../../common/services/crud.service';
 import { CoreModelConstructor } from '../../../common/types/core-model-constructor.type';
 import { CoreAiConversationCreateInput } from '../inputs/core-ai-conversation-create.input';
@@ -21,8 +23,15 @@ export { AI_CONVERSATION_CLASS, AI_CONVERSATION_MODEL } from '../core-ai.constan
  * CRUD service for multi-turn {@link CoreAiConversation}s.
  *
  * `appendMessage()` adds a turn via `$push` (never round-trips the subdocument
- * array through `update()`). Ownership is enforced by the model's `securityCheck`
- * and by the resolver/controller passing `S_CREATOR`/`S_SELF` roles.
+ * array through `update()`). `findForCurrentUser()` is the shared owner-scoped
+ * list used by both the REST controller and the GraphQL resolver.
+ *
+ * Ownership is enforced differently per operation shape:
+ * - single-object `get`/`delete`: the controller/resolver pass
+ *   `S_CREATOR`/`S_SELF`, evaluated against the loaded `dbObject`.
+ * - list (`findForCurrentUser`): a list has no single `dbObject`, so the gate
+ *   uses `S_USER` and ownership is scoped by the server-computed `createdBy`
+ *   filterQuery plus the model's `securityCheck`.
  */
 @Injectable()
 export class CoreAiConversationService extends CrudService<
@@ -37,8 +46,105 @@ export class CoreAiConversationService extends CrudService<
     @InjectModel(AI_CONVERSATION_MODEL) protected override readonly mainDbModel: Model<AiConversationDocument>,
     @Inject(AI_CONVERSATION_CLASS)
     protected override readonly mainModelConstructor: CoreModelConstructor<CoreAiConversation>,
+    @InjectConnection() protected readonly connection: Connection,
   ) {
     super();
+  }
+
+  /**
+   * List the AI conversations visible to the current user. By default — for
+   * every user, admins included — this returns only the caller's own
+   * conversations, newest first. An admin may opt in to the cross-user view
+   * (every user's conversations) by passing `{ all: true }`; the flag is
+   * ignored for non-admins, so it can never widen a regular user's scope.
+   *
+   * Each result carries its `createdBy` owner id. In the admin cross-user view
+   * (`all: true`) each result additionally carries a resolved `createdByUser`
+   * (`{ id, email, firstName, lastName, username }`) so the list is attributable
+   * to named users; on a normal own-only fetch that lookup is skipped, since the
+   * owner is the caller. The heavy `messages` subdocument array is excluded from
+   * the list payload — fetch a single conversation via `get()` for the full
+   * message history.
+   *
+   * Shared by the REST controller (`GET /ai/conversations`) and the GraphQL
+   * resolver (`findAiConversations`) so both API surfaces enforce ownership
+   * identically and cannot drift apart.
+   *
+   * A LIST operation has no single `dbObject`, so the per-document roles
+   * `S_CREATOR` / `S_SELF` can never be satisfied at the operation level —
+   * passing them rejected every non-admin with a 403 before ownership scoping
+   * ran. The operation gate therefore uses `[S_USER]`; the server-computed
+   * `createdBy` filterQuery and the model `securityCheck` scope the result to
+   * the owner.
+   */
+  async findForCurrentUser(
+    serviceOptions?: ServiceOptions,
+    options?: { all?: boolean },
+  ): Promise<CoreAiConversation[]> {
+    const currentUser = serviceOptions?.currentUser;
+    const isAdmin = !!currentUser?.roles?.includes(RoleEnum.ADMIN);
+    // Default is own-only for everyone; only an admin may opt in to all users' conversations.
+    const seeAll = isAdmin && options?.all === true;
+    const filterQuery = seeAll ? {} : { createdBy: currentUser?.id };
+    const conversations = await this.find(
+      { filterQuery, queryOptions: { sort: { createdAt: -1 } } },
+      { ...serviceOptions, roles: [RoleEnum.S_USER], select: '-messages' },
+    );
+    // Resolve creators to named users ONLY for the admin cross-user view — a normal
+    // fetch returns just the caller's own conversations, so the owner is already known.
+    if (seeAll && conversations.length) {
+      await this.attachCreators(conversations);
+    }
+    return conversations;
+  }
+
+  /**
+   * Attach a lightweight resolved creator (`{ id, email, firstName, lastName,
+   * username }`) as `createdByUser` to each conversation, so an admin's
+   * cross-user list is attributable to named users. Read-only lookup of
+   * non-sensitive identity fields via the shared `User` model on the same
+   * connection; fails soft (leaves `createdByUser` unset) when no `User` model is
+   * registered. Never called on a normal own-only fetch.
+   */
+  protected async attachCreators(conversations: CoreAiConversation[]): Promise<void> {
+    const ids = [
+      ...new Set(
+        conversations
+          .map((conversation) => conversation.createdBy)
+          .filter(Boolean)
+          .map(String),
+      ),
+    ];
+    if (!ids.length) {
+      return;
+    }
+    let userModel: Model<any>;
+    try {
+      userModel = this.connection.model('User');
+    } catch {
+      // No `User` model registered on this connection (exotic setup) — skip attribution.
+      return;
+    }
+    const users = await userModel
+      .find({ _id: { $in: ids } })
+      .select('email firstName lastName username')
+      .lean()
+      .exec();
+    const byId = new Map(
+      (users as any[]).map((user) => [
+        String(user._id),
+        {
+          email: user.email,
+          firstName: user.firstName,
+          id: String(user._id),
+          lastName: user.lastName,
+          username: user.username,
+        },
+      ]),
+    );
+    for (const conversation of conversations) {
+      conversation.createdByUser = byId.get(String(conversation.createdBy));
+    }
   }
 
   /**

--- a/tests/ai.e2e-spec.ts
+++ b/tests/ai.e2e-spec.ts
@@ -343,6 +343,105 @@ describe('AI module (e2e)', () => {
     await conversationService.delete(conversation.id, { currentUser: admin, roles: [RoleEnum.ADMIN, RoleEnum.S_CREATOR] });
   });
 
+  it('scopes AI conversation listing: non-admin own-only (200 not 403), admin own-by-default with ?all opt-in, createdBy attribution', async () => {
+    // Regression: findConversations passed roles [ADMIN, S_CREATOR, S_SELF] on a LIST.
+    // A list has no single dbObject, so the per-document roles S_CREATOR / S_SELF can
+    // never be satisfied — every non-admin was rejected at the operation level (403)
+    // before ownership scoping ran. The list now uses roles [S_USER]; the createdBy
+    // filterQuery + the model securityCheck still scope the result to the owner.
+    const suffix = Math.random().toString(36).slice(2, 8);
+    const myTitle = `Mine ${suffix}`;
+    const theirTitle = `Theirs ${suffix}`;
+
+    // A second, independent non-admin user for the isolation half.
+    const otherEmail = `ai-http-regular2-${Date.now()}-${Math.random().toString(36).slice(2)}@test.com`;
+    const otherToken = await createHttpUser(otherEmail, []);
+
+    // Each non-admin creates a conversation over HTTP.
+    const mineRes = await request(app.getHttpServer())
+      .post('/ai/conversations')
+      .set('Authorization', `Bearer ${httpRegularToken}`)
+      .send({ title: myTitle });
+    expect(mineRes.status).toBe(201);
+
+    const theirRes = await request(app.getHttpServer())
+      .post('/ai/conversations')
+      .set('Authorization', `Bearer ${otherToken}`)
+      .send({ title: theirTitle });
+    expect(theirRes.status).toBe(201);
+
+    // The non-admin lists their own conversations — must be 200 (was 403).
+    const listRes = await request(app.getHttpServer())
+      .get('/ai/conversations')
+      .set('Authorization', `Bearer ${httpRegularToken}`);
+    expect(listRes.status).toBe(200);
+    const titles = (listRes.body as any[]).map((c) => c.title);
+    expect(titles).toContain(myTitle);
+    // Isolation: a non-admin never sees another user's conversation.
+    expect(titles).not.toContain(theirTitle);
+    // The heavy messages array is omitted from the list payload.
+    expect((listRes.body as any[]).every((c) => c.messages === undefined)).toBe(true);
+    // Each result carries its createdBy owner id (attribution).
+    const mineRow = (listRes.body as any[]).find((c) => c.title === myTitle);
+    expect(mineRow?.createdBy).toBeDefined();
+    // Own-only fetch does not resolve creators (the owner is the caller) — createdByUser stays unset.
+    expect(mineRow?.createdByUser).toBeUndefined();
+
+    // A non-admin cannot escalate to the cross-user view via ?all=true — still own only.
+    const regularAllRes = await request(app.getHttpServer())
+      .get('/ai/conversations?all=true')
+      .set('Authorization', `Bearer ${httpRegularToken}`);
+    expect(regularAllRes.status).toBe(200);
+    const regularAllTitles = (regularAllRes.body as any[]).map((c) => c.title);
+    expect(regularAllTitles).toContain(myTitle);
+    expect(regularAllTitles).not.toContain(theirTitle);
+
+    // Admin default fetch → own only (must NOT contain the two non-admins' conversations).
+    const adminOwnRes = await request(app.getHttpServer())
+      .get('/ai/conversations')
+      .set('Authorization', `Bearer ${httpAdminToken}`);
+    expect(adminOwnRes.status).toBe(200);
+    const adminOwnTitles = (adminOwnRes.body as any[]).map((c) => c.title);
+    expect(adminOwnTitles).not.toContain(myTitle);
+    expect(adminOwnTitles).not.toContain(theirTitle);
+
+    // Admin opt-in ?all=true → sees every user's conversations, each attributable via createdBy.
+    const adminAllRes = await request(app.getHttpServer())
+      .get('/ai/conversations?all=true')
+      .set('Authorization', `Bearer ${httpAdminToken}`);
+    expect(adminAllRes.status).toBe(200);
+    const adminAll = adminAllRes.body as any[];
+    const adminAllTitles = adminAll.map((c) => c.title);
+    expect(adminAllTitles).toContain(myTitle);
+    expect(adminAllTitles).toContain(theirTitle);
+    const mineOwned = adminAll.find((c) => c.title === myTitle);
+    const theirOwned = adminAll.find((c) => c.title === theirTitle);
+    expect(mineOwned?.createdBy).toBeDefined();
+    expect(theirOwned?.createdBy).toBeDefined();
+    // The owner mapping distinguishes the two conversations' users.
+    expect(mineOwned.createdBy).not.toBe(theirOwned.createdBy);
+    // The admin cross-user view resolves each creator to a named user (createdByUser).
+    expect(mineOwned.createdByUser?.email).toBe(httpRegularEmail);
+    expect(theirOwned.createdByUser?.email).toBe(otherEmail);
+
+    // Clean up both conversations + the extra user and its auth artifacts.
+    await db.collection('aiConversations').deleteMany({ title: { $in: [myTitle, theirTitle] } });
+    const otherUser = await db.collection('users').findOne({ email: otherEmail });
+    await db.collection('users').deleteOne({ email: otherEmail });
+    await db.collection('iam_user').deleteMany({ email: otherEmail });
+    if (otherUser?.iamId) {
+      await db.collection('account').deleteMany({ userId: otherUser.iamId });
+      await db.collection('session').deleteMany({ userId: otherUser.iamId });
+    }
+  });
+
+  it('rejects an unauthenticated AI conversation list with 401 (not 403)', async () => {
+    // @Roles(S_USER) with no token → unauthenticated → 401 (per the 401/403 policy);
+    // authenticating could grant access, so a 401 (not 403) is the correct signal.
+    const res = await request(app.getHttpServer()).get('/ai/conversations');
+    expect(res.status).toBe(401);
+  });
+
   it('exposes an MCP endpoint that rejects unauthenticated requests with 401', async () => {
     const res = await request(app.getHttpServer())
       .post('/ai/mcp')
@@ -761,6 +860,72 @@ describe('AI module (e2e)', () => {
     );
     expect(res.errors).toBeDefined();
     expect(res.errors[0].message).toMatch(/Access denied|Forbidden|Insufficient|Unauthorized/i);
+  });
+
+  it('lets a non-admin list their own conversations over GraphQL (not Access denied) and isolates them', async () => {
+    // Regression twin of the REST fix: findAiConversations passed roles [ADMIN, S_CREATOR,
+    // S_SELF] on a LIST, so every non-admin was rejected with "Access denied" over GraphQL —
+    // exactly the bug the REST fix targeted, on the parallel API surface. Both endpoints now
+    // delegate to CoreAiConversationService.findForCurrentUser ([S_USER] + createdBy filterQuery
+    // + model securityCheck), so a non-admin sees only their own conversations here too.
+    const suffix = Math.random().toString(36).slice(2, 8);
+    const myTitle = `GqlMine ${suffix}`;
+    const theirTitle = `GqlTheirs ${suffix}`;
+
+    // A second, independent non-admin user for the isolation half.
+    const otherEmail = `ai-gql-regular2-${Date.now()}-${Math.random().toString(36).slice(2)}@test.com`;
+    const otherToken = await createHttpUser(otherEmail, []);
+
+    const mineRes = await request(app.getHttpServer())
+      .post('/ai/conversations')
+      .set('Authorization', `Bearer ${httpRegularToken}`)
+      .send({ title: myTitle });
+    expect(mineRes.status).toBe(201);
+    const theirRes = await request(app.getHttpServer())
+      .post('/ai/conversations')
+      .set('Authorization', `Bearer ${otherToken}`)
+      .send({ title: theirTitle });
+    expect(theirRes.status).toBe(201);
+
+    // List via GraphQL as the non-admin — must return data, never an Access-denied error (was 403-equivalent).
+    const res = await testHelper.graphQl(
+      { fields: ['id', 'title'], name: 'findAiConversations', type: TestGraphQLType.QUERY },
+      { token: httpRegularToken },
+    );
+    expect(res.errors).toBeUndefined();
+    expect(Array.isArray(res)).toBe(true);
+    const titles = (res as any[]).map((c) => c.title);
+    expect(titles).toContain(myTitle);
+    // Isolation: a non-admin never sees another user's conversation over GraphQL either.
+    expect(titles).not.toContain(theirTitle);
+
+    // Admin opt-in over GraphQL: `all: true` returns every user's conversations, each with createdBy + resolved createdByUser.
+    const adminAll = await testHelper.graphQl(
+      {
+        arguments: { all: true },
+        fields: ['id', 'title', 'createdBy', 'createdByUser'],
+        name: 'findAiConversations',
+        type: TestGraphQLType.QUERY,
+      },
+      { token: httpAdminToken },
+    );
+    expect(adminAll.errors).toBeUndefined();
+    const adminAllTitles = (adminAll as any[]).map((c) => c.title);
+    expect(adminAllTitles).toContain(myTitle);
+    expect(adminAllTitles).toContain(theirTitle);
+    // The resolved creator identity is present over GraphQL too (admin cross-user view).
+    const gqlMineRow = (adminAll as any[]).find((c) => c.title === myTitle);
+    expect(gqlMineRow?.createdByUser?.email).toBe(httpRegularEmail);
+
+    // Clean up both conversations + the extra user and its auth artifacts.
+    await db.collection('aiConversations').deleteMany({ title: { $in: [myTitle, theirTitle] } });
+    const otherUser = await db.collection('users').findOne({ email: otherEmail });
+    await db.collection('users').deleteOne({ email: otherEmail });
+    await db.collection('iam_user').deleteMany({ email: otherEmail });
+    if (otherUser?.iamId) {
+      await db.collection('account').deleteMany({ userId: otherUser.iamId });
+      await db.collection('session').deleteMany({ userId: otherUser.iamId });
+    }
   });
 
   // ===================================================================================================================


### PR DESCRIPTION
Release **11.31.2**.

Fixes non-admins receiving 403 / "Access denied" when listing their own AI conversations (REST `GET /ai/conversations` and GraphQL `findAiConversations`), and adds an admin cross-user view (`?all=true` / `all: true`) with creator attribution (`createdByUser`).

- Shared `CoreAiConversationService.findForCurrentUser()` for REST + GraphQL (no drift).
- Default own-only for everyone; admin opt-in `?all=true`; non-admins cannot escalate.
- Behavior change (admins): default list is now own-only — use `?all=true` for all. See [migration guide](migration-guides/11.31.1-to-11.31.2.md).

`check` green: 2184 tests, 0 audit vulns, build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)