### PR TITLE
11.32.1: missing migrations/ no longer blocks boot, core spec kept vendor-safe

### DIFF
--- a/FRAMEWORK-API.md
+++ b/FRAMEWORK-API.md
@@ -1,6 +1,6 @@
 # @lenne.tech/nest-server — Framework API Reference
 
-> Auto-generated from source code on 2026-07-22 (v11.32.0)
+> Auto-generated from source code on 2026-07-22 (v11.32.1)
 > File: `FRAMEWORK-API.md` — compact, machine-readable API surface for Claude Code
 
 ## CoreModule.forRoot()

--- a/migration-guides/11.32.0-to-11.32.1.md
+++ b/migration-guides/11.32.0-to-11.32.1.md
@@ -1,0 +1,84 @@
+# Migration Guide: 11.32.0 → 11.32.1
+
+## Overview
+
+| Category | Change | Effort |
+|----------|--------|--------|
+| **Bugfix** | A missing `migrations/` directory no longer blocks the server boot | None — automatic |
+| **Bugfix** | A spec in `src/core/` no longer breaks vendor-mode projects | None — automatic |
+
+**No code changes required.** Both fixes are internal.
+
+## Quick Migration
+
+```bash
+pnpm update @lenne.tech/nest-server
+```
+
+Vendor-mode projects: `/lt-dev:backend:update-nest-server-core`.
+
+---
+
+## What was fixed
+
+### A missing `migrations/` directory no longer blocks the boot
+
+`MigrationRunner.loadMigrationFiles()` called `fs.readdirSync()` without checking that the
+directory exists. A missing directory threw `ENOENT` — and because the standard start script is
+`migrate:up && start:local`, the `&&` turned that into a server that never starts, with an error
+that does not point at the cause.
+
+This is a state people produce routinely: *"delete all migrations"* reads to most as *"throw the
+folder away"*.
+
+A missing directory now means the same thing as an empty one — there are no migrations:
+
+```
+[migrate] migrations directory not found — treating as empty: ./migrations
+```
+
+`up()` and `status()` continue and exit 0. **`down()` is unchanged and still fails hard** —
+rollback is an explicit operator action, never a boot path, and an exit 0 with no rollback
+performed would mislead scripted rollbacks. `NSC__MIGRATE__STRICT=true` still turns a
+recorded-but-missing migration into a hard error, so the integrity guard is intact.
+
+If your project kept a `migrations/.gitkeep` purely to work around this, you can drop it — though
+keeping it does no harm.
+
+> Tracked as DEV-2634.
+
+### A `src/core/` spec no longer breaks vendor-mode projects
+
+`hub-mermaid.helper.spec.ts` mixed a value and a type import in one statement
+(`import { buildErDiagram, type HubModelDescriptor } from …`). The lt CLI's vendor conversion drops
+the inline `type` specifier, so the file arrived in vendored projects as
+`import { buildErDiagram }` and failed to compile with `TS2304: Cannot find name
+'HubModelDescriptor'` — breaking `pnpm run check` in every freshly generated vendor-mode project.
+
+The import is now split into two statements, which survives the conversion. Only vendor-mode
+projects were affected; npm-mode consumers never saw it.
+
+> The underlying CLI defect is tracked separately. Splitting the import keeps `src/core/`
+> vendor-safe regardless.
+
+---
+
+## Compatibility Notes
+
+| Pattern | Status |
+|---------|:------:|
+| Everything from 11.32.0 | Unchanged |
+| `MigrationRunner` public API | Unchanged |
+| `down()` behaviour on a missing rollback file | Unchanged (still hard error) |
+| `NSC__MIGRATE__STRICT` | Unchanged |
+
+Still relevant from the previous release: **[the two security overrides your project needs](11.31.3-to-11.32.0.md#security-add-two-overrides)** — pnpm `overrides:` are not inherited from this package. If you skipped that step, do it now.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `ENOENT: no such file or directory, scandir './migrations'` on start | Pre-11.32.1 | Update; no code change needed |
+| `TS2304: Cannot find name 'HubModelDescriptor'` in a vendored core | Pre-11.32.1 vendored copy | Re-sync the core, or split the import in that one spec by hand |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lenne.tech/nest-server",
-  "version": "11.32.0",
+  "version": "11.32.1",
   "description": "Modern, fast, powerful Node.js web framework in TypeScript based on Nest with a GraphQL API and a connection to MongoDB (or other databases).",
   "keywords": [
     "node",

--- a/spectaql.yml
+++ b/spectaql.yml
@@ -19,7 +19,7 @@ servers:
 info:
   title: lT Nest Server
   description: Modern, fast, powerful Node.js web framework in TypeScript based on Nest with a GraphQL API and a connection to MongoDB (or other databases).
-  version: 11.32.0
+  version: 11.32.1
   contact:
     name: lenne.Tech GmbH
     url: https://lenne.tech

--- a/src/core/modules/hub/helpers/hub-mermaid.helper.spec.ts
+++ b/src/core/modules/hub/helpers/hub-mermaid.helper.spec.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildErDiagram, type HubModelDescriptor } from './hub-mermaid.helper';
+// Value and type imports are deliberately split into two statements. The lt CLI's vendor
+// conversion drops an INLINE `type` specifier from a mixed import — `{ buildErDiagram, type
+// HubModelDescriptor }` arrives in a vendored project as `{ buildErDiagram }`, and the file then
+// fails to compile with TS2304. Keeping the two forms separate survives the conversion.
+// (The CLI defect is tracked separately; this keeps src/core/ vendor-safe meanwhile.)
+import type { HubModelDescriptor } from './hub-mermaid.helper';
+
+import { buildErDiagram } from './hub-mermaid.helper';
 
 describe('buildErDiagram', () => {
   const models: HubModelDescriptor[] = [

--- a/src/core/modules/migrate/migration-runner.ts
+++ b/src/core/modules/migrate/migration-runner.ts
@@ -159,6 +159,23 @@ export class MigrationRunner {
    * compiled-production intent; the duplicate is skipped with a warning.
    */
   private async loadMigrationFiles(): Promise<MigrationFile[]> {
+    // A MISSING directory means the same thing as an EMPTY one: there are no migrations.
+    // Treat it that way instead of throwing ENOENT.
+    //
+    // This is a boot blocker otherwise: `pnpm start` is `migrate:up && start:local`, so the `&&`
+    // turns a readdirSync ENOENT into a server that will not start — with an error that does not
+    // point at the cause. And it is a state people produce routinely: "delete all migrations"
+    // reads to most as "throw the folder away".
+    //
+    // The runner already tolerates the RELATED case — a migration recorded in the database whose
+    // file is gone is non-fatal unless `NSC__MIGRATE__STRICT` is set. Only the wholly absent
+    // directory fell outside that tolerance. `down()` stays hard, consistent with its own
+    // reasoning. See DEV-2634.
+    if (!fs.existsSync(this.options.migrationsDirectory)) {
+      console.warn(`[migrate] migrations directory not found — treating as empty: ${this.options.migrationsDirectory}`);
+      return [];
+    }
+
     const files = fs
       .readdirSync(this.options.migrationsDirectory)
       .filter((file) => this.pattern.test(file))

--- a/tests/unit/migration-runner-missing-directory.spec.ts
+++ b/tests/unit/migration-runner-missing-directory.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * Unit Tests: MigrationRunner tolerates a MISSING migrations directory (DEV-2634)
+ *
+ * A missing directory means the same thing as an empty one — there are no migrations — and
+ * must behave identically instead of throwing ENOENT.
+ *
+ * Why this is a boot blocker and not a cosmetic error: the starter's `start` script is
+ * `migrate:up && start:local`, so the `&&` turns a `readdirSync` ENOENT into a server that
+ * never starts, with an error that does not point at the cause. And it is a state people
+ * produce routinely — "delete all migrations" reads to most as "throw the folder away".
+ *
+ * The runner already tolerates the RELATED case (a migration recorded in the database whose
+ * file is gone is non-fatal unless `NSC__MIGRATE__STRICT` is set). Only the wholly absent
+ * directory fell outside that tolerance, which made the behaviour inconsistent.
+ *
+ * `down()` stays hard on purpose: rollback is an explicit operator action, never a boot path,
+ * and an exit 0 with no rollback performed would mislead scripted rollbacks.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import type { MigrationSet, MongoStateStore } from '../../src/core/modules/migrate/mongo-state-store';
+
+import { MigrationRunner } from '../../src/core/modules/migrate/migration-runner';
+
+/** State store stub serving a fresh copy per load, capturing every save. */
+function fakeStore(recorded: { timestamp?: number; title: string }[] = []): {
+  saves: MigrationSet[];
+  store: MongoStateStore;
+} {
+  const saves: MigrationSet[] = [];
+  const store = {
+    loadAsync: async () => ({ migrations: recorded.map((m) => ({ ...m })), up: () => {} }),
+    saveAsync: async (set) => {
+      saves.push(set);
+    },
+  } satisfies Pick<MongoStateStore, 'loadAsync' | 'saveAsync'> as unknown as MongoStateStore;
+  return { saves, store };
+}
+
+/** A path that is guaranteed not to exist. */
+function missingDir(): string {
+  return path.join(os.tmpdir(), `nest-server-migrations-absent-${process.pid}-${Math.trunc(performance.now())}`);
+}
+
+const savedStrictEnv = process.env.NSC__MIGRATE__STRICT;
+beforeAll(() => {
+  delete process.env.NSC__MIGRATE__STRICT;
+});
+afterAll(() => {
+  if (savedStrictEnv === undefined) {
+    delete process.env.NSC__MIGRATE__STRICT;
+  } else {
+    process.env.NSC__MIGRATE__STRICT = savedStrictEnv;
+  }
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('MigrationRunner with a missing migrations directory', () => {
+  it('up() resolves instead of throwing ENOENT', async () => {
+    const dir = missingDir();
+    expect(fs.existsSync(dir)).toBe(false);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { saves, store } = fakeStore();
+
+    const runner = new MigrationRunner({ migrationsDirectory: dir, stateStore: store });
+
+    await expect(runner.up()).resolves.not.toThrow();
+    // Nothing ran, so nothing may be recorded — a phantom state entry would make a later,
+    // restored migration silently "already applied".
+    expect(saves).toEqual([]);
+  });
+
+  it('up() warns so the operator sees WHY nothing ran', async () => {
+    const dir = missingDir();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { store } = fakeStore();
+
+    await new MigrationRunner({ migrationsDirectory: dir, stateStore: store }).up();
+
+    expect(warn.mock.calls.flat().join(' ')).toContain('migrations directory not found');
+  });
+
+  it('status() reports an empty set rather than throwing', async () => {
+    const dir = missingDir();
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { store } = fakeStore();
+
+    const status = await new MigrationRunner({ migrationsDirectory: dir, stateStore: store }).status();
+
+    expect(status.pending).toEqual([]);
+    expect(status.completed).toEqual([]);
+  });
+
+  it('behaves identically to an EMPTY directory — that is the whole point', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nest-server-migrations-empty-'));
+    try {
+      const fromEmpty = await new MigrationRunner({
+        migrationsDirectory: emptyDir,
+        stateStore: fakeStore().store,
+      }).status();
+      const fromMissing = await new MigrationRunner({
+        migrationsDirectory: missingDir(),
+        stateStore: fakeStore().store,
+      }).status();
+
+      expect(fromMissing.pending).toEqual(fromEmpty.pending);
+      expect(fromMissing.completed).toEqual(fromEmpty.completed);
+    } finally {
+      fs.rmSync(emptyDir, { force: true, recursive: true });
+    }
+  });
+
+  it('still reports a recorded-but-missing migration as missing, not as an error', async () => {
+    // The pre-existing tolerance must keep working when the whole directory is gone, not just
+    // when a single file is.
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { store } = fakeStore([{ timestamp: 1_699_000_000_000, title: '1699000000000-foo.ts' }]);
+
+    const status = await new MigrationRunner({ migrationsDirectory: missingDir(), stateStore: store }).status();
+
+    expect(status.missing).toEqual(['1699000000000-foo.ts']);
+  });
+
+  it('strict mode still fails hard — tolerance is a default, not a removal of the guard', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { store } = fakeStore([{ timestamp: 1_699_000_000_000, title: '1699000000000-foo.ts' }]);
+
+    const runner = new MigrationRunner({ migrationsDirectory: missingDir(), stateStore: store, strict: true });
+
+    await expect(runner.up()).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
Patch release for **11.32.1**. Two internal fixes, no consumer code changes.

## A missing `migrations/` directory no longer blocks the boot (DEV-2634)

`MigrationRunner.loadMigrationFiles()` called `fs.readdirSync()` without an existence guard. Because the standard start script is `migrate:up && start:local`, the `&&` turned an `ENOENT` into a server that never starts — with an error that does not point at the cause. And it is a state people produce routinely: *"delete all migrations"* reads to most as *"throw the folder away"*.

A missing directory now behaves exactly like an empty one. `down()` is deliberately unchanged and still fails hard, and `NSC__MIGRATE__STRICT` still turns a recorded-but-missing migration into a hard error — the tolerance is a default, not a removal of the guard. Six unit tests cover it, including the empty-vs-missing equivalence and the strict-mode case.

## A core spec no longer breaks vendor-mode projects

`hub-mermaid.helper.spec.ts` mixed a value and a type import in one statement. The lt CLI's vendor conversion drops the inline `type` specifier, so vendored projects got `import { buildErDiagram }` and failed to compile with `TS2304` — breaking `pnpm run check` in **every** freshly generated vendor-mode project.

Found by the fullstack smoke test. The import is split into two statements, which survives the conversion. The underlying CLI defect is tracked separately; this keeps `src/core/` vendor-safe meanwhile.

## Verification

`pnpm run check` green: audit 0 findings, lint clean, 2385 tests / 99 files, build, manifest, server-start. Additionally validated end-to-end by a full smoke test: a generated fullstack project deployed to dev and production, both stages verified online (health-check 200, `/meta` commit == CI SHA, Let's Encrypt certs, sign-up 201).

Merge with a **merge commit**, not squash.