### PR TITLE
11.32.4

### DIFF
--- a/.claude/agent-memory/lt-dev-devops-reviewer/MEMORY.md
+++ b/.claude/agent-memory/lt-dev-devops-reviewer/MEMORY.md
@@ -4,5 +4,6 @@
 - [Review uncommitted worktree](feedback_review-uncommitted-worktree.md) — releases reviewed via `git diff HEAD` + untracked files on `develop`; pipeline already GREEN, static review only.
 
 ## Project Context
-- [Infra surface](project_infra-surface.md) — DOES ship reference Docker infra (corrected); compose lives in lt-monorepo; no memory limits, no prod NODE_OPTIONS, `pnpm audit` not in CI.
-- [PID-1 signal contract](project_pid1-signal-contract.md) — node is PID 1 via `exec`; `enableShutdownHooks()` never called, so remove-listener+re-raise is swallowed in-container.
+- [Infra surface](project_infra-surface.md) — ships reference Docker infra; `pnpm audit` IS a blocking CI gate; tini + shutdown hooks landed in 11.32.0; compose lives in lt-monorepo.
+- [pnpm audit & overrides mechanics](project_pnpm-audit-and-overrides.md) — built-in 24h `minimumReleaseAge`, what `pnpm audit --fix` auto-writes, check.mjs mis-renders ignored advisories, minimatch export-shape trap.
+- [PID-1 signal contract](project_pid1-signal-contract.md) — SUPERSEDED by 11.32.0 (tini + `enableShutdownHooks()`); kept so the stale conclusion is not re-derived.

--- a/.claude/agent-memory/lt-dev-devops-reviewer/project_infra-surface.md
+++ b/.claude/agent-memory/lt-dev-devops-reviewer/project_infra-surface.md
@@ -1,17 +1,22 @@
 ---
 name: project-infra-surface
-description: nest-server is a library but DOES ship reference Docker infra (Dockerfile, docker-entrypoint.sh, .dockerignore, .env.example) that downstream projects copy — plus JS/TS build tooling
+description: nest-server is a library but DOES ship reference Docker infra (Dockerfile, docker-entrypoint.sh, .dockerignore, .env.example) that downstream projects copy — plus JS/TS build tooling and a blocking pnpm audit CI gate
 metadata:
   type: project
 ---
 
-**CORRECTED 2026-07-22** — an earlier version of this memory claimed "no Docker/compose/CI-YAML infra". That is WRONG. Verify with `ls` before trusting any inventory here.
+**CORRECTED 2026-07-22, RE-VERIFIED 2026-07-30** — an early version claimed "no Docker/compose/CI-YAML
+infra" (wrong), and the 2026-07-22 version's "known gaps" list is now largely stale (see below).
+Verify with `ls` / `grep` before trusting any inventory here.
 
-`@lenne.tech/nest-server` is a published **framework library**, but it ALSO ships **reference infrastructure** that `nest-server-starter` and consumer projects copy and adapt:
+`@lenne.tech/nest-server` is a published **framework library**, but it ALSO ships **reference
+infrastructure** that `nest-server-starter` and consumer projects copy and adapt:
 
-- `Dockerfile` — 3-stage (deps/builder/runner), `node:24-alpine` **digest-pinned**, non-root `nodejs:1001`, `HEALTHCHECK` on `GET /health-check`, `EXPOSE 3000`, `ARG API_DIR` for standalone-vs-monorepo builds.
-- `docker-entrypoint.sh` — migrations then `exec node …/main.js`. **`exec` ⇒ node becomes PID 1.**
-- `.dockerignore`, `.env.example` (`.env` + `.env.*` gitignored; `.env.example` tracked).
+- `Dockerfile` — 3-stage (deps/builder/runner), `node:24-alpine` **digest-pinned**, non-root
+  `nodejs:1001`, `HEALTHCHECK` on `GET /health-check`, `EXPOSE 3000`, `ARG API_DIR` for
+  standalone-vs-monorepo builds, **`tini` as PID 1**.
+- `docker-entrypoint.sh` — migrations, then `exec $SERVER_CMD`.
+- `.dockerignore`, `.env.example` (`.env` + `.env.*` gitignored AND dockerignored; `.env.example` tracked).
 - `.github/workflows/{build,publish}.yml`.
 
 **Deployment shape lives elsewhere:** there is NO compose file in this repo. The real one is
@@ -19,26 +24,29 @@ metadata:
 `restart: unless-stopped`, no host port for mongo). Always read it when judging runtime behaviour —
 this repo's Dockerfile alone does not show the deployed configuration.
 
-**Known infra gaps in the reference stack (verified 2026-07-22, still open):**
-- **No memory limit anywhere** — not in the Dockerfile, not in the monorepo compose (no
-  `deploy.resources.limits.memory` / `mem_limit` on api, app or mongo).
-- **No `NODE_OPTIONS` / heap ceiling in production** — it exists only in `nodemon.json` (dev).
-  Note V8's default already lands ~4 GB on a ≥16 GB host, so `--max-old-space-size=4096` is a
-  measured no-op there; V8 is cgroup-blind, so the value only matters against a container limit.
-- **`enableShutdownHooks()` is never called** anywhere in the repo — only mentioned in comments.
-  Combined with node-at-PID-1 this governs signal behaviour; see [[project-pid1-signal-contract]].
-- `docker-entrypoint.sh` here has **drifted** from the starter's (which is best-effort, layout-aware,
-  seam-injected and unit-tested via `tests/unit/docker-entrypoint.spec.ts`). Diff both before judging.
-  The starter deliberately lets a FAILED migration continue to server start; this repo's `set -e` copy aborts.
-- This repo's entrypoint hardcodes `dist/src/main.js`, but this repo's own build emits `dist/main.js`
-  (`start:prod`). The path is correct for the **starter** layout only.
+**Fixed since the 2026-07-22 snapshot (do NOT re-report these as gaps):**
+- **`tini` IS now PID 1** (`RUN apk add --no-cache tini`, `ENTRYPOINT ["/sbin/tini", "--", …]`) and
+  **`server.enableShutdownHooks()` IS now called** (`src/main.ts:124`). Both landed in 11.32.0
+  (commit d0e56d1). This supersedes the old [[project-pid1-signal-contract]] analysis.
+- **The entrypoint no longer hardcodes a main.js path** — it probes `$DIST/src/main.js` then
+  `$DIST/main.js` and errors explicitly if neither exists, so it is correct for BOTH this repo's
+  layout (`dist/main.js`) and the starter's (`dist/src/main.js`).
+- **`pnpm audit` IS in CI** — `.github/workflows/build.yml` step "Audit dependencies", **blocking**
+  (no `continue-on-error`). It runs on every branch push. `publish.yml` still does NOT audit.
+
+**Still-open infra gaps (verified 2026-07-30):**
+- **No memory limit anywhere** — not in the Dockerfile, not in the monorepo compose.
+- **No production `NODE_OPTIONS` heap ceiling — and that is now DELIBERATE**, documented in
+  `docker-entrypoint.sh` (pinning a literal disables Node's cgroup-aware auto-sizing, so the cgroup
+  OOM-killer fires before V8's graceful FATAL). Do not "fix" this.
+- **No `docker-entrypoint` unit test in this repo** — only `tests/unit/pnpm-pin-contract.spec.ts`.
+  The starter has `tests/unit/docker-entrypoint.spec.ts`; diff both before judging.
+  The starter deliberately lets a FAILED migration continue; this repo aborts by default
+  (`MIGRATE_FAILURE_POLICY=warn` opts out).
+- No coverage upload, no `lt server permissions` gate (the scanner targets consumer projects).
 
 **Other (non-Docker) review surface:** `scripts/check.mjs`, `vitest.config.ts` + `vitest-e2e.config.ts`,
-`pnpm-workspace.yaml` `overrides:` (targets must be fixed versions; moved out of `package.json` in the
-pnpm 11 upgrade), `bin/migrate.js` (3-layout resolver).
-
-**CI reality:** both workflows run `pnpm run prepublishOnly` (= `lint && test:ci`) + `pnpm run build`.
-**`pnpm audit` is NOT in CI** — it lives only in the maintainer-run `check`/`check:raw` chain. So
-security overrides are validated locally, never by the pipeline. No coverage upload, no permissions gate.
+`pnpm-workspace.yaml` (see [[project-pnpm-audit-and-overrides]] — non-obvious pnpm 11 mechanics),
+`bin/migrate.js` (3-layout resolver).
 
 See [[feedback-review-uncommitted-worktree]] for how these reviews are requested.

--- a/.claude/agent-memory/lt-dev-devops-reviewer/project_pid1-signal-contract.md
+++ b/.claude/agent-memory/lt-dev-devops-reviewer/project_pid1-signal-contract.md
@@ -1,39 +1,31 @@
 ---
 name: project-pid1-signal-contract
-description: Node runs as PID 1 in the reference container and enableShutdownHooks() is never called — so any "remove listener + re-raise signal" pattern is silently swallowed
+description: SUPERSEDED as of 11.32.0 — tini is now PID 1 and enableShutdownHooks() is called, so the old "signal swallowed at PID 1" analysis no longer describes this repo
 metadata:
   type: project
 ---
 
-In the reference container, **Node is PID 1**: `docker-entrypoint.sh` ends with `exec node …/main.js`,
-which replaces the shell. This holds in `nest-server` AND in `nest-server-starter`. Nothing adds
-`tini` / `--init` / `STOPSIGNAL`.
+**SUPERSEDED 2026-07-30.** Kept only so the old conclusion is not re-derived from a stale note.
 
-**Why this matters:** Linux marks a PID-namespace init process `SIGNAL_UNKILLABLE`. A userspace signal
-whose disposition is `SIG_DFL` is silently discarded (`sig_task_ignored()` in `kernel/signal.c`).
-So the common Node pattern
+**What changed:** release 11.32.0 (commit d0e56d1) added **both** halves of the fix:
+- `Dockerfile`: `RUN apk add --no-cache tini` + `ENTRYPOINT ["/sbin/tini", "--", "/app/docker-entrypoint.sh"]`
+  → tini is PID 1, the entrypoint shell is PID 2, and `exec $SERVER_CMD` makes node PID 2.
+  **Node is no longer PID 1.**
+- `src/main.ts:124`: `server.enableShutdownHooks();` is now actually called.
 
-```js
-process.removeListener(sig, handler);   // last listener → disposition back to SIG_DFL
-process.kill(process.pid, sig);         // …and at PID 1 this is a NO-OP
-```
+So the previous conclusion — "a `removeListener` + `process.kill(process.pid, sig)` re-raise is
+silently discarded because a PID-namespace init is `SIGNAL_UNKILLABLE`, and the loop never drains" —
+**no longer applies to the reference container.** tini forwards signals and reaps orphans;
+`enableShutdownHooks()` drains the loop via `app.close()`.
 
-**terminates correctly in dev but is swallowed in the container.** Verified empirically: as non-PID-1
-the process dies with 143; the re-raise only fails at PID 1. Because the HTTP server is still
-listening, the event loop is non-empty, so the process does not exit on its own either — `docker stop`
-waits out the grace period and SIGKILLs.
+**The underlying kernel fact is still true and still worth applying elsewhere:** a signal whose
+disposition is `SIG_DFL` is discarded for PID 1 (`sig_task_ignored()`, `kernel/signal.c`), so the
+`removeListener` + re-raise pattern is a no-op there. That bites any container that runs node
+directly as PID 1 with no init — check `nest-server-starter` and any consumer Dockerfile that
+predates 11.32.0 before assuming they inherited this fix.
 
-`app.enableShutdownHooks()` is **never called** in this repo (grep finds it only inside comments).
-Any code branching on `listenerCount(signal) <= 1` therefore always takes the "I am alone" branch —
-the "let Nest own the exit" branch is dead code in the reference implementation.
+**How to apply:** when reviewing shutdown / graceful-drain / zero-downtime behaviour in this stack,
+still check all three together — is there a real init at PID 1, is `enableShutdownHooks()` called,
+and does anything drain the event loop — but for THIS repo the answer to all three is now yes.
 
-**Why:** noted while reviewing the `process-diagnostics.helper.ts` change set (2026-07-22), whose whole
-purpose was making silent deaths diagnosable — this is the one silent death it does not fix.
-
-**How to apply:** whenever reviewing signal handling, shutdown, zero-downtime deploys or graceful
-drain in this stack, check all three together — PID-1 status, whether `enableShutdownHooks()` is
-actually called, and whether anything drains the event loop. Judging the JS handler alone gives the
-wrong answer. Note Nest's own shutdown hooks end with the same `process.kill` re-raise; they work at
-PID 1 only because `app.close()` drains the event loop first, not because the re-raise lands.
-
-See [[project-infra-surface]] for the rest of the reference-infra inventory.
+See [[project-infra-surface]] for the current reference-infra inventory.

--- a/.claude/agent-memory/lt-dev-devops-reviewer/project_pnpm-audit-and-overrides.md
+++ b/.claude/agent-memory/lt-dev-devops-reviewer/project_pnpm-audit-and-overrides.md
@@ -1,0 +1,46 @@
+---
+name: project-pnpm-audit-and-overrides
+description: Non-obvious pnpm 11 mechanics behind pnpm-workspace.yaml in this repo — built-in 24h minimumReleaseAge, what `pnpm audit --fix` auto-writes, and how check.mjs mis-renders ignored advisories
+metadata:
+  type: project
+---
+
+Mechanics you cannot derive from the repo files alone, verified against the pinned
+**pnpm 11.13.1** dist (`~/.cache/node/corepack/v1/pnpm/<version>/dist/pnpm.mjs` — greppable).
+
+**Why:** the 2026-07-30 review of the `auditConfig` / `minimumReleaseAgeExclude` / `minimatch`
+change set turned on all three of these, and each one flips a "this entry is inert" verdict.
+
+**How to apply:** check these before calling any `pnpm-workspace.yaml` entry inert, machine-written,
+or a silent suppression.
+
+1. **`minimumReleaseAge` has a BUILT-IN 24-hour default** (`"minimum-release-age": 24 * 60` in the
+   pnpm dist). So `minimumReleaseAgeExclude` is **never inert** for absence of an explicit
+   `minimumReleaseAge:` key — the policy is on by default.
+
+2. **`pnpm audit --fix` auto-writes BOTH the override and the exclude.** `createOverrides()` emits
+   the `pkg@>=<floor> <<patched>: <patched>` key shape, and `createMinimumReleaseAgeExcludes()`
+   emits `pkg@<minVersion>` entries into `minimumReleaseAgeExclude` in `pnpm-workspace.yaml`.
+   `package.json` has `check:fix` = `… pnpm audit --fix …`, so **an un-commented entry in either
+   block is probably machine-generated, not hand-authored** — and the machine picks the floor,
+   which is how an over-broad multi-major key gets in past a repo rule that forbids exactly that.
+
+3. **`auditConfig.ignoreGhsas` at pnpm-workspace.yaml TOP LEVEL is correct for pnpm 11** and it does
+   gate the exit code (`auditConfig` is in `MIGRATED_PNPM_FIELD_KEYS`; the filter runs before both
+   the JSON and table branches of the audit handler). `ignoreCves` was removed in pnpm 11.
+   Verify empirically with `pnpm audit` — it prints `Severity: 1 high (1 ignored)` and exits 0.
+
+4. **`scripts/check.mjs` renders ignored advisories as if they were live.** pnpm deliberately leaves
+   `metadata.vulnerabilities` UNfiltered (so it can report "(N ignored)" separately) and only filters
+   `advisories`. `runAudit()` reads `metadata.vulnerabilities` for its counts but takes `blocking`
+   from the exit code — so after any `ignoreGhsas` entry, `pnpm run check` prints a **green check
+   next to a live-looking "1 high"**. Not a gate failure; a reporting mismatch. `check.mjs` has no
+   notion of pnpm's `ignoredVulnerabilities`.
+
+**Export-shape trap for `minimatch` overrides** (re-usable evidence, empirically tested):
+majors **5, 6, 7, 8 are callable CJS** (`module.exports = minimatch`; 6-8 via `dist/cjs/index-cjs.js`,
+which also sets `.default`), while **9 and 10 are NOT callable** (`dist/commonjs/index.js`,
+`__esModule: true`, no `.default`). So any override key floored below `9.0.0` that targets 10.x
+pre-authorizes a `"… is not a function"` runtime break. Floor such keys at `>=9.0.0`.
+
+See [[project-infra-surface]] for the rest of the review surface.

--- a/.claude/agent-memory/lt-dev-docs-reviewer/MEMORY.md
+++ b/.claude/agent-memory/lt-dev-docs-reviewer/MEMORY.md
@@ -8,4 +8,6 @@
 - [main.ts opt-in APIs are invisible](main-ts-optin-api-has-no-doc-surface.md) — a helper consumers must wire into their OWN main.ts has no automatic doc surface; the migration guide is the only one that reaches them
 - [Release version artifacts](release-version-artifacts.md) — a version bump must touch package.json AND spectaql.yml; the lockstep is a git-history convention, written in no rule doc
 - [Migration-guide self-description traps](migration-guide-behavior-change-count-trap.md) — never trust a guide's Overview counts or its "aligns with existing pattern X" claims; derive both from the source diff
+- [Comment-density baseline](comment-density-baseline.md) — src/core is 33% comments with 227 blocks >=15 lines; long narrative JSDoc is house style, grade duplication/placement/accuracy instead
+- [migrate CLI exit guard is dead](migrate-cli-exit-guard-dead-through-bin-shim.md) — `require.main === module` never true through bin/migrate.js (both bins + docker-entrypoint); check the shim before believing a CLI-lifecycle claim
 - [AI module false doc claims](ai-module-false-doc-claims.md) — `authorize()` is plan-mode-only, MCP has no confirmation gate, MCP SDK is a regular dep; both claims now CORRECTED in live surfaces as of 11.32.2 (facts still true; don't re-flag fixed surfaces)

--- a/.claude/agent-memory/lt-dev-docs-reviewer/comment-density-baseline.md
+++ b/.claude/agent-memory/lt-dev-docs-reviewer/comment-density-baseline.md
@@ -1,0 +1,32 @@
+---
+name: comment-density-baseline
+description: Measured house-style baseline for src/core comment density — 33% comment lines, 227 blocks >=15 lines, max 61; use it before grading a long narrative JSDoc as "over-commented"
+metadata:
+  type: project
+---
+
+**Long narrative JSDoc blocks that retell a past incident ARE this repo's house style, not an anomaly.**
+Measured on `src/core/**/*.ts` (specs excluded), 2026-07-30:
+
+- 55,353 lines, **18,299 comment lines = 33.1%**
+- **227 block comments >= 15 lines** (of 2,723 blocks total)
+- Longest: 61 lines (`src/core/common/helpers/process-diagnostics.helper.ts`), then 60 (`core-tenant.guard.ts`), 57 (`core-better-auth.controller.ts`), 54/49/47/47 (`server-options.interface.ts`)
+- Non-`.ts` precedent is stronger still: `bin/migrate.js` opens with a 27-line docblock, `docker-entrypoint.sh` is ~40 lines of narrative rationale.
+
+**Why:** "Is this 20-line docblock excessive?" is a recurring grading question, and answering *yes* against
+this baseline penalises the author for following the codebase's most consistent convention. Recomputing the
+number costs a scripted pass over 55k lines, so it is worth carrying.
+
+**How to apply:** Do NOT grade a 15-25 line explanatory block as over-commenting — it lands mid-pack here.
+Grade the three things that actually go wrong instead:
+1. **Duplication.** The same incident narrative written verbatim in two or three places will drift. (Seen: the
+   GridFS chunk-completeness story told twice inside `migration.helper.ts`, plus the "`migrate up` never
+   exits" story told in both `migrate-cli.ts` and `migration.helper.ts`.)
+2. **Placement.** The half of the narrative that answers *"should I upgrade?"* (user-visible symptom, blast
+   radius) is release-note content and belongs in `migration-guides/`; the source should keep only the
+   mechanism that answers *"why is this code shaped this way?"*.
+3. **Accuracy.** A docblock asserting what a change fixes is a claim to verify against the source, never to
+   accept — see [[migrate-cli-exit-guard-dead-through-bin-shim]] and [[ai-module-false-doc-claims]].
+
+A useful secondary signal: the ratio of **added** comment lines to added lines in the diff. 57% in a change
+whose files already sit at 40-52% is consistent; it is the duplication, not the ratio, that costs points.

--- a/.claude/agent-memory/lt-dev-docs-reviewer/doc-surfaces-for-config-features.md
+++ b/.claude/agent-memory/lt-dev-docs-reviewer/doc-surfaces-for-config-features.md
@@ -16,4 +16,18 @@ When a branch adds a new configurable feature or core module, these doc surfaces
 7. `docs/REQUEST-LIFECYCLE.md` — only if new controllers/resolvers/interceptors/middleware/routes change the request flow.
 8. `migration-guides/` — required when a developer must do more than `pnpm update` to use/accommodate the feature (a new opt-in module with new env vars + a main.ts edit for MCP OAuth qualifies). See .claude/rules/migration-guides.md.
 
+## Dependency-governance surfaces (separate set — easy to miss entirely)
+
+A change to `pnpm-workspace.yaml` has its own doc obligations, and the two rule docs are BOTH incomplete:
+
+- `docs/security-overrides.md` — advertised in CLAUDE.md as *"the rules for writing your own"* overrides.
+- `.claude/rules/package-management.md` §Overrides — has "Safe Override Workflow" + "Document Why Each Override Exists".
+
+**Neither documents `auditConfig.ignoreGhsas` or `minimumReleaseAgeExclude`** (verified 2026-07-30: zero hits
+across all repo `.md`). When a diff introduces a *knowingly-unfixed advisory* the governing rule ends up living
+only as a YAML comment — which the next editor writes around. A new dependency-governance MECHANISM (not just a
+new entry) must land in `.claude/rules/package-management.md`; a new *entry* under an existing mechanism only
+needs its inline rationale comment. Note that every `overrides:` entry in that file carries a rationale comment
+— an entry without one is an outlier worth flagging.
+
 **Common consistency trap:** the override-field list often diverges across (a) the runtime `CoreXxxModule.forRoot()` options interface, (b) the public `ICoreModuleOverrides.<mod>` type, and (c) the two configurable-features.md tables. core.module.ts typically spreads `...overrides?.<mod>` into forRoot, so runtime may accept MORE fields than the public type declares — meaning some documented/runtime fields are not passable via the typed API. Cross-check all three.

--- a/.claude/agent-memory/lt-dev-docs-reviewer/migrate-cli-exit-guard-dead-through-bin-shim.md
+++ b/.claude/agent-memory/lt-dev-docs-reviewer/migrate-cli-exit-guard-dead-through-bin-shim.md
@@ -1,0 +1,41 @@
+---
+name: migrate-cli-exit-guard-dead-through-bin-shim
+description: The `require.main === module` block in migrate-cli.ts NEVER runs through the shipped `migrate` bin — bin/migrate.js imports and calls main(), so any CLI process-lifecycle claim must be checked against the shim
+metadata:
+  type: project
+---
+
+`src/core/modules/migrate/cli/migrate-cli.ts` guards its CLI bootstrap with `if (require.main === module)`.
+**That block is dead code on every shipped invocation path.** `bin/migrate.js` — which is BOTH declared bins
+(`migrate` and `nest-migrate` in `package.json`) — ends with:
+
+```js
+const { main } = require(cliPath);
+main();
+```
+
+So `require.main` is `bin/migrate.js`, `module` is `migrate-cli.js`, the comparison is **false** (verified
+empirically), and anything inside that block — `process.exit(0)`, `process.exit(1)`, the `.catch()` — never
+fires. `bin/migrate.js` supplies no `.catch()` of its own, so a failure there is an unhandled rejection
+rather than the exit code the guard block promises.
+
+`docker-entrypoint.sh` reaches the CLI through this shim in **both** consumption modes
+(`$MIGRATE_BIN` = `/app/node_modules/.bin/migrate` in npm mode, `node $DIST/bin/migrate.js` in vendor mode),
+so the container path is covered by the shim too, not by the guard.
+
+**Why:** A 2026-07-30 change first put its exit inside that guard, with a docblock naming the exact scenario
+it fixes — *"a container entrypoint of the shape `migrate up && node main.js` never reaches the server at
+all"*. That scenario runs through `bin/migrate.js`, i.e. the one path the guard does not reach, so the fix
+would have shipped as a claim rather than a behaviour.
+
+**Status as of 11.32.4 (RESOLVED — do not re-report):** the exit moved OUT of the guard into an exported
+`runCli()`, and `bin/migrate.js` now calls `cli.runCli || cli.main` with its own `.catch()`. The guard block
+still exists and is still dead through the shim — it covers only a direct `node migrate-cli.js` — but nothing
+load-bearing lives inside it any more, and `migrate-cli.ts` says so in its own docblock. The structural trap
+below is unchanged; only this one instance is closed.
+
+**How to apply:** Whenever a diff touches CLI process lifecycle (exit codes, signal handling, "runs only when
+executed directly"), open `bin/migrate.js` before grading the claim. State in the review whether the change
+reaches the shim path, the direct-`node` path, or both. Same discipline as
+[[migration-guide-behavior-change-count-trap]]: derive the behaviour from the source, never from the comment
+that describes it. Related: [[comment-density-baseline]].

--- a/.claude/agent-memory/lt-dev-performance-reviewer/MEMORY.md
+++ b/.claude/agent-memory/lt-dev-performance-reviewer/MEMORY.md
@@ -3,12 +3,14 @@
 ## Project
 - [AI Module Performance Profile](ai-module-perf.md) — per-prompt DB query budget + memory characteristics of src/core/modules/ai; what to re-check vs what's already correct.
 - [Hub Module Performance Profile](hub-module-perf.md) — admin cockpit: verified zero-cost gating + single-poller model; the 5 low-severity findings to re-check as it evolves.
+- [Migrate Module Performance Profile](migrate-module-perf.md) — boot/CLI-only (no HTTP path); the per-migration state save is deliberate crash-safety, do NOT flag as N+1.
 
 ## Build & Startup
 - [SWC/CJS TDZ + CI Gap](swc-cjs-tdz-and-ci-gap.md) — circular-import crashes hit `nest start -b swc` but NOT CI (vitest's unplugin-swc misses it); includes the cycle-triage rule.
 
 ## Micro-costs (measured, reusable)
 - [ConfigService.get cost](config-service-get-cost.md) — measured 152 ns/call (rfdc factory rebuilt every call); `getFastButReadOnly` is the 79 ns option. Only matters inside loops.
+- [GridFS verify + stream costs](gridfs-verify-and-stream-costs.md) — COUNT_SCAN is index-only but O(chunks); connect/close ~43 ms/file; `pipe()` leaks the source on client abort; `process.exit()` truncates piped stdout at 64 KB.
 
 ## Memory & Process
 - [Heap Ceiling + Sync stderr](heap-ceiling-and-sync-stderr.md) — measured: `--max-old-space-size=4096` is a no-op on 32GB hosts; bare `node` in prod is correct (cgroup auto-sizing); `writeSync(2)` blocks forever on a stalled pipe.

--- a/.claude/agent-memory/lt-dev-performance-reviewer/gridfs-verify-and-stream-costs.md
+++ b/.claude/agent-memory/lt-dev-performance-reviewer/gridfs-verify-and-stream-costs.md
@@ -1,0 +1,85 @@
+---
+name: gridfs-verify-and-stream-costs
+description: Measured costs for the GridFS upload-verify + download-pipe paths — COUNT_SCAN is index-only but O(chunks), MongoClient connect/close is ~43ms/file on localhost, pipe() leaks the source on client abort, and process.exit() truncates piped stdout at 64 KB.
+metadata:
+  type: project
+---
+
+Measured 2026-07-30 on Node v24.12.0 / local mongod, while reviewing the GridFS
+upload-verification + download-pipe change set. All four were counter-intuitive enough to be
+worth not re-deriving.
+
+## 1. `countDocuments({files_id})` DOES use the GridFS default index — but scans one key per chunk
+
+GridFS auto-creates `{files_id: 1, n: 1}` (unique, background) on `<bucket>.chunks`. The driver's
+`countDocuments` compiles to `$match` + `$group`, and MongoDB optimizes that into **COUNT_SCAN**:
+
+| file | chunks | stage | keysExamined | docsExamined |
+|---|---|---|---|---|
+| 10 KB | 1 | COUNT_SCAN | 1 | **0** |
+| 50 MB | 201 | COUNT_SCAN | 201 | **0** |
+| 30 MB @1KB | 30720 | COUNT_SCAN | 30720 | **0** |
+
+So it is index-only (never touches documents) but **O(chunks) in index keys**. The bounded
+alternative `findOne({files_id}, {sort:{n:-1}, projection:{_id:0,n:1}})` is **PROJECTION_COVERED
+with keysExamined = 1** regardless of size, and detects the same realistic failure mode (GridFS
+writes `n` as a 0..N-1 prefix, so a partial upload truncates the tail).
+
+**Watch the missing-index case:** a bucket whose chunks collection was non-empty at first upload
+never gets the index (driver skips creation) → the same count becomes a **COLLSCAN** over the whole
+chunks collection. Verified by pre-seeding a decoy chunk doc.
+
+**Gotcha:** `expected = Math.max(1, ceil(length/chunkSize))` is wrong for a **0-byte file** —
+GridFS stores **0** chunks for it, so the `max(1, …)` floor makes a valid empty file look incomplete.
+
+## 2. `MongoClient.connect()` per file costs ~43 ms — close() costs ~0.4 ms
+
+Measured p50 over 40 iterations, localhost, **no TLS, no auth, no SRV**:
+
+| shape | p50 |
+|---|---|
+| connect + op + close (per-file) | **44.1 ms** |
+| shared client, op only | **0.73 ms** |
+| `close()` alone | **0.43 ms** |
+
+So per-file connect/close overhead is ~43 ms and is **~100x the cost of the two verification
+queries** (~0.4 ms combined). Adding `close()` is nearly free; the *connect* is the expensive half,
+and it predates the verification work. A `mongodb+srv://` + TLS + SCRAM target adds SRV/TXT DNS,
+TLS and 2 SCRAM round trips on top — treat 43 ms as a **floor**, not the production number.
+
+Leaving clients open (the old shape) cost 84 active handles for 40 files and kept the event loop
+alive forever — the "migrate up never exits" symptom.
+
+**How to apply:** N-file migration loops should share one client keyed by URI. `getDb()` in
+`migration.helper.ts` has the same per-call connect shape.
+
+## 3. `pipe()` installs its error handler on the DESTINATION only — and never destroys the source
+
+Verified with listener counts and abort simulation:
+
+- `src.pipe(dst)` → `src.listenerCount('error')` stays **0**, `dst` goes to **1**. A source error is
+  therefore unhandled unless you add your own handler.
+- **Destination destroyed mid-stream (client aborts a download) → `source.destroyed === false`,
+  still holding its buffered chunks (64 KB in the harness).** With a GridFS read stream that is also
+  a live server-side cursor. One leak per aborted download.
+- `stream.pipeline(src, dst, cb)` destroys the source automatically in the same scenario.
+
+**How to apply:** handling only the source-error direction is half the fix. For download endpoints,
+`pipeline()` covers both directions; downloads are exactly where client aborts are common.
+
+## 4. `process.exit()` truncates piped stdout at the 64 KB kernel pipe buffer
+
+Against a deliberately slow consumer, a process writing ~450 KB then calling `process.exit(0)`
+delivered exactly **65500 bytes** — everything past the pipe buffer was discarded. The identical run
+without `process.exit()` lost nothing (it correctly blocked until drained).
+
+Below ~64 KB of pending output it is **not** reachable — writes land in the kernel buffer
+synchronously. It is also **load-dependent**: on an idle machine 5000 lines survived 10/10 runs; the
+one truncation to 3426 lines happened while the box was saturated by a concurrent test suite.
+
+**How to apply:** stdout to a **file or TTY** is safe; a **pipe** is not — and Docker's log driver
+and CI log shippers are pipes. A CLI that must exit explicitly should flush first
+(`process.stdout.write('', cb)`) rather than exit inline. Never dismiss this as theoretical because
+"it worked locally" — local usually means a TTY.
+
+Related: [[migrate-module-perf]], [[heap-ceiling-and-sync-stderr]]

--- a/.claude/agent-memory/lt-dev-security-reviewer/MEMORY.md
+++ b/.claude/agent-memory/lt-dev-security-reviewer/MEMORY.md
@@ -14,10 +14,11 @@
 - [project-template-render-traversal.md](project-template-render-traversal.md) — UPDATED 2026-07-20: renderTemplate NOW HAS an absolute-path containment guard + Hub sendTestEmail inventory-validates; both old findings FIXED — re-verify before re-reporting
 - [project-hub-module-security-model.md](project-hub-module-security-model.md) — Hub cockpit gating mechanics; TOP risks = external-guard dependency (Hub+no-auth=open) and CSRF under cors.allowAll+SameSite=None; roles:false prod guard now exists
 - [project-process-diagnostics-helper.md](project-process-diagnostics-helper.md) — writeSync(2) EBADF/EPIPE throw exits 7 and masks the error; signal abdication vs Nest traced; unhandledRejection flips Node's fail-fast default
+- [project-gridfs-and-express-response-facts.md](project-gridfs-and-express-response-facts.md) — GridFS stores 0 chunks for a 0-byte file; res.json() keeps a preset Content-Type; pipe() leaks the source on client abort; process.exit() truncates piped stdout
 
 ## Review Methodology
 
-- [project-pnpm-overrides-propagation.md](project-pnpm-overrides-propagation.md) — workspace overrides never reach npm consumers (@nestjs/graphql exact-pins vulnerable ws@8.20.1); override-necessity test recipe; pnpm overrides are downgrade-LOCKS
+- [project-pnpm-overrides-propagation.md](project-pnpm-overrides-propagation.md) — overrides never reach npm consumers; TWO exact-pin leaks (ws@8.20.1, js-yaml@5.2.1); docs/security-overrides.md must be updated; `pnpm audit --prod` triage for ignoreGhsas
 
 - [project-e2e-node-env-trap.md](project-e2e-node-env-trap.md) — e2e without NODE_ENV=e2e fabricates 5 bogus BetterAuth "Invalid credentials" failures; reproduces on base branch too, so a control-diff won't catch it
 - [project-betterauth-native-cookie-forwarding.md](project-betterauth-native-cookie-forwarding.md) — BetterAuth native-handler paths forward Set-Cookie verbatim, bypass the cookie helper's Secure flag; useSecureCookies:false (11.27.6) drops Secure on 2FA/social/magic-link session cookies

--- a/.claude/agent-memory/lt-dev-security-reviewer/feedback-typeof-detection.md
+++ b/.claude/agent-memory/lt-dev-security-reviewer/feedback-typeof-detection.md
@@ -1,5 +1,5 @@
 ---
-name: CoreModule.forRoot() typeof detection and Type<any> classification
+name: feedback-typeof-detection
 description: The isIamOnlyMode detection changed from undefined-check to typeof-check in 11.22.0; Type<any> in ICoreModuleOverrides is the correct NestJS pattern
 type: project
 ---

--- a/.claude/agent-memory/lt-dev-security-reviewer/project-ai-mcp-oauth-refresh-token-binding.md
+++ b/.claude/agent-memory/lt-dev-security-reviewer/project-ai-mcp-oauth-refresh-token-binding.md
@@ -1,5 +1,5 @@
 ---
-name: ai-mcp-oauth-refresh-token-binding
+name: project-ai-mcp-oauth-refresh-token-binding
 description: MCP OAuth refresh-token rotation in CoreAiMcpOAuthService.exchangeRefreshToken does not validate the rotating client matches the issuing client — cross-client token theft risk when ai.mcp.oauth is enabled
 metadata:
   type: project

--- a/.claude/agent-memory/lt-dev-security-reviewer/project-ai-module-secret-stripping.md
+++ b/.claude/agent-memory/lt-dev-security-reviewer/project-ai-module-secret-stripping.md
@@ -1,5 +1,5 @@
 ---
-name: ai-module-secret-stripping
+name: project-ai-module-secret-stripping
 description: AI module 3-layer apiKeyEncrypted protection; secretFields now MERGES with defaults (11.26.0 fix — fragility resolved); MCP PKCE enforced by SDK
 metadata:
   type: project

--- a/.claude/agent-memory/lt-dev-security-reviewer/project-gridfs-and-express-response-facts.md
+++ b/.claude/agent-memory/lt-dev-security-reviewer/project-gridfs-and-express-response-facts.md
@@ -1,0 +1,43 @@
+---
+name: project-gridfs-and-express-response-facts
+description: Verified library behaviors that keep biting the file-download and migrate-GridFS paths — GridFS stores ZERO chunks for a 0-byte file, Express res.json() never overrides an already-set Content-Type, stream.pipe() does not destroy the source on client abort, and process.exit() truncates piped stdout.
+metadata:
+  type: project
+---
+
+# Four verified behaviors behind the file/GridFS/CLI paths
+
+All four were confirmed empirically on 2026-07-30 (Express 5.2.1, mongodb driver in-tree,
+Node 24.12) while reviewing `core-file.controller.ts` + `migration.helper.ts`. They are library
+facts, not project code, so they stay true across refactors — and each one has already produced a
+real defect here.
+
+1. **GridFS writes NO chunk document for a zero-byte file.** Driver source
+   `node_modules/mongodb/lib/gridfs/upload.js` → `writeRemnant()` returns early on `stream.pos === 0`
+   ("Buffer is empty, so don't bother to insert"). Only the `.files` doc with `length: 0` is stored.
+   Any chunk-count verification of the shape `Math.max(1, Math.ceil(length / chunkSize))` therefore
+   **rejects valid empty files**. The correct expected count is plain
+   `Math.ceil((length || 0) / chunkSize)` — which is 0 for an empty file.
+
+2. **`res.json()` does NOT override an already-set `Content-Type`.** Express guards it with
+   `if (!this.get('Content-Type'))`. On a file-download route that already set
+   `Content-Type: image/png`, an error-path `res.status(404).json(...)` ships a JSON body labelled
+   `image/png; charset=utf-8`. `res.send()` DOES fix `Content-Length` and regenerates a correct
+   weak `ETag`, so those two are not stale — Content-Type is the only header that lies.
+
+3. **`stream.pipe(res)` does not destroy the SOURCE when the client aborts.** Node's pipe only
+   `unpipe()`s. A public download endpoint therefore leaks one GridFS read stream + cursor per
+   aborted request. Needs an explicit `res.on('close', () => stream.destroy())`.
+
+4. **`process.exit()` truncates piped stdout.** Reproduced: 60 001 `console.log` lines → only 18 662
+   reached the pipe, 4.87 MB still in `process.stdout.writableLength`, and the final
+   "completed successfully" line was lost. Node's stdout is async on a pipe, which is exactly what
+   Docker/CI/`| tee` give you. Relevant wherever a CLI's output IS the audit record (migrate).
+
+**How to apply:** when a change adds chunk-count verification, an error path on a streaming
+response, a `pipe()` to a response, or an explicit `process.exit()`, check it against the matching
+item above before accepting the accompanying comment or unit test. Stub-based unit tests
+(`responseStub`, `dbStub`) cannot catch 1, 2 or 3 — items 1 and 2 both slipped through green specs
+that asserted the *wrong* behavior.
+
+Related: [[project-exception-wire-format]], [[project-process-diagnostics-helper]]

--- a/.claude/agent-memory/lt-dev-security-reviewer/project-npm-files-exposure.md
+++ b/.claude/agent-memory/lt-dev-security-reviewer/project-npm-files-exposure.md
@@ -1,5 +1,5 @@
 ---
-name: npm files array includes .claude/rules and CLAUDE.md
+name: project-npm-files-exposure
 description: Since 11.22.0, .claude/rules/**/* and CLAUDE.md are explicitly included in the npm package files array for AI-assisted development in consuming projects
 type: project
 ---

--- a/.claude/agent-memory/lt-dev-security-reviewer/project-pnpm-overrides-propagation.md
+++ b/.claude/agent-memory/lt-dev-security-reviewer/project-pnpm-overrides-propagation.md
@@ -1,6 +1,6 @@
 ---
-name: pnpm-overrides-propagation
-description: pnpm-workspace.yaml overrides do NOT reach npm consumers of @lenne.tech/nest-server; @nestjs/graphql exact-pins vulnerable ws@8.20.1. Plus how to run the override-necessity test and pnpm's downgrade-lock mechanic.
+name: project-pnpm-overrides-propagation
+description: pnpm-workspace.yaml overrides do NOT reach npm consumers of @lenne.tech/nest-server; TWO confirmed exact-pin leaks (@nestjs/graphql->ws@8.20.1, @nestjs/swagger->js-yaml@5.2.1). docs/security-overrides.md is the consumer-facing list and must be updated with every new prod override. Plus the override-necessity test, the --prod triage for ignoreGhsas, and pnpm's downgrade-lock mechanic.
 metadata:
   type: project
 ---
@@ -20,11 +20,42 @@ patched >= 8.21.0). An exact pin cannot be resolved away, and `@nestjs/graphql` 
 unless it copies the override itself. nest-server's own `ws: 8.21.1` direct dep does not help — both
 versions coexist in the tree and `@nestjs/graphql` binds to its nested 8.20.1.
 
+**Second confirmed case (2026-07-30, DEV-2698 review):** `@nestjs/swagger@11.4.6` — also a plain
+prod `dependencies` entry — declares `"js-yaml": "5.2.1"`, again an **exact pin**. js-yaml `<=5.2.1`
+is GHSA-pm4m-ph32-ghv5 (high, exponential parsing time in flow collections; verified against the npm
+bulk-advisory endpoint). Same shape as `ws`, same consequence: every consumer ships it. This is now a
+**pattern, not an accident** — when a new prod override appears, check `node -p "require('./node_modules/<parent>/package.json').dependencies['<pkg>']"`
+for an exact pin, because that is the class that cannot self-heal.
+
+**`docs/security-overrides.md` is the consumer-facing contract** and IS shipped (`docs/**` is in the
+npm `files` array). It currently lists only `ws` + `@hono/node-server`. **Any new override on a PROD
+path must be added there in the same change** — otherwise the framework's audit goes green while
+every consumer stays vulnerable and has no way to learn about it. Treat a missing doc entry as the
+finding, not as a nit.
+
+**Self-healing vs. not — check the declared range before flagging.** A transitive override is only a
+propagation gap when the parent's declared range cannot reach the fix. `@ts-morph/common` declares
+`minimatch: ^10.0.1` and `minimatch@10.2.6` declares `brace-expansion: ^5.0.8` — a fresh consumer
+install resolves those forward on its own, so those overrides are repo-local hygiene, not consumer
+exposure. Only exact pins (and dead majors like the MCP SDK's `^1.19.9`) are real leaks.
+
 **How to apply:** when reviewing any override/audit change in this repo, always ask the second
 question — "does the consumer inherit the fix?" A clean `pnpm audit` here is not evidence about
 downstream. Per the global "Grund-Repos" rule, the durable fix belongs in `nest-server-starter`'s
 `pnpm-workspace.yaml` (the template every project starts from) and/or a shipped doc under `docs/**`
 (which IS in the npm `files` array). Do not accept "pnpm audit is green" as closing the finding.
+
+## Triaging an `auditConfig.ignoreGhsas` suppression: run `pnpm audit --prod` FIRST
+
+`ignoreGhsas` is a **global GHSA-ID filter with no path or package scoping** — it hides the advisory
+everywhere, including a future PROD occurrence of the same ID. Before accepting one that is justified
+as "dev-only", run `pnpm audit --prod`. If that is already clean, the narrower instrument exists and
+the global suppression is over-broad: the CI gate should be `pnpm audit --prod` (blocking) plus a
+non-blocking full audit, not a permanent ID suppression. Verified 2026-07-30: `pnpm audit` reported
+`1 high (1 ignored)` while `pnpm audit --prod` reported `No known vulnerabilities found`.
+
+`pnpm why <pkg>` is the authoritative check for the "only one path remains" claim — it prints the
+full chain and tags each root as `(dependencies)` or `(devDependencies)`.
 
 ## The override-necessity test (project rule requires it)
 

--- a/.claude/agent-memory/lt-dev-security-reviewer/project-process-diagnostics-helper.md
+++ b/.claude/agent-memory/lt-dev-security-reviewer/project-process-diagnostics-helper.md
@@ -1,5 +1,5 @@
 ---
-name: process-diagnostics-helper
+name: project-process-diagnostics-helper
 description: process-diagnostics.helper.ts semantics verified 2026-07-22 — writeSync(2) throws EBADF/EPIPE and a throw inside uncaughtException exits 7 masking the original; signal abdication is correct vs Nest but unconditional; unhandledRejection flips Node's fail-fast default.
 metadata:
   type: project

--- a/.dockerignore
+++ b/.dockerignore
@@ -21,18 +21,50 @@ dist
 # Environment
 .env
 .env.*
+# Registry auth. Empty of secrets in git, but this is where CI writes
+# `//registry.npmjs.org/:_authToken=$NPM_TOKEN` before a build — and Dockerfile's
+# deps stage COPYs it, so a token would be baked into an image layer for good.
+.npmrc
+
+# Credentials / keys — defensive, none of these are in the repo today
+*.pem
+*.key
+*.crt
+*.p12
+id_rsa*
 
 # Logs
-*.log
+# NOTE: Docker ignore patterns are NOT gitignore patterns. A pattern without a
+# leading `**` is anchored to the context root, and `*` never crosses a `/`. So
+# a bare `*.log` matches ONLY top-level files — hence the `**/` prefixes.
+# Two patterns rather than one `**/*.log*`: that shorter form would also swallow
+# a source file named `foo.logger.ts` and quietly drop it from the build.
+**/*.log
+**/*.log.*
 npm-debug.log*
 .pnpm-debug.log*
+
+# Runtime state — written while the server runs locally, never read by a build.
+# `uploads` is the TUS staging directory, i.e. real user documents; it is in
+# .gitignore for the same reason, which also means it never shows up in
+# `git status` to remind anyone it is sitting in the build context.
+# `**/` is load-bearing: the Dockerfile supports a monorepo build
+# (`--build-arg API_DIR=projects/api` from the repo root), where the directory is
+# `projects/api/uploads` and a bare `uploads` would not match it.
+**/uploads
+# `lt dev`'s directory: detached server logs + scratch state.
+**/.lt-dev
 
 # Testing
 tests
 coverage
 test-results
 playwright-report
+blob-report
 .nyc_output
+# Kept only when `check:swc-tdz` fails, and gitignored — so it is invisible in
+# `git status` while still sitting in the build context.
+dist-swc-tdz
 
 # Documentation (not needed in runtime image)
 docs
@@ -48,6 +80,7 @@ docker-compose*
 # CI/CD
 .gitlab-ci.yml
 .gitlab
+.github
 
 # Misc
 .DS_Store

--- a/FRAMEWORK-API.md
+++ b/FRAMEWORK-API.md
@@ -1,6 +1,6 @@
 # @lenne.tech/nest-server — Framework API Reference
 
-> Auto-generated from source code on 2026-07-24 (v11.32.3)
+> Auto-generated from source code on 2026-07-30 (v11.32.4)
 > File: `FRAMEWORK-API.md` — compact, machine-readable API surface for Claude Code
 
 ## CoreModule.forRoot()

--- a/bin/migrate.js
+++ b/bin/migrate.js
@@ -93,7 +93,17 @@ if (require.main === module) {
     }
   }
 
-  // Load and run the CLI
-  const { main } = require(cliPath);
-  main();
+  // Load and run the CLI.
+  //
+  // Prefer runCli(): it drains stdout and then exits explicitly, so a handle left
+  // behind by MongoDB/GridFS cannot keep the process alive after the work is done
+  // (a migration step that never returns blocks the container before the server
+  // ever starts). main() is the fallback for a dist built before runCli existed —
+  // it resolves normally but relies on the event loop draining by itself.
+  const cli = require(cliPath);
+  const run = cli.runCli || cli.main;
+  Promise.resolve(run()).catch((error) => {
+    console.error('Fatal error:', error);
+    process.exitCode = 1;
+  });
 }

--- a/docs/security-overrides.md
+++ b/docs/security-overrides.md
@@ -11,16 +11,18 @@ A green `pnpm audit` inside the framework repo says nothing about your tree.
 
 ## What this concretely means for you
 
-The framework pulls in two transitive packages that resolve to a **vulnerable** version unless you
+The framework pulls in three transitive packages that resolve to a **vulnerable** version unless you
 override them yourself:
 
 | Package | Advisory | Why it cannot resolve forward on its own |
 |---------|----------|------------------------------------------|
 | `ws` | [GHSA-96hv-2xvq-fx4p](https://github.com/advisories/GHSA-96hv-2xvq-fx4p) — high: memory-exhaustion DoS + uninitialized memory disclosure. Patched `>=8.21.0` | `@nestjs/graphql` declares `"ws": "8.20.1"` — an **exact pin**, not a caret. No amount of updating moves it |
 | `@hono/node-server` | [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9) (static-file path traversal) + [GHSA-9mqv-5hh9-4cgg](https://github.com/advisories/GHSA-9mqv-5hh9-4cgg) (unauthenticated memory leak). Patched `>=2.0.10` | `@modelcontextprotocol/sdk` declares `^1.19.9` and ships **no 1.x fix line**, so the fix is only available across a major |
+| `js-yaml` | [GHSA-pm4m-ph32-ghv5](https://github.com/advisories/GHSA-pm4m-ph32-ghv5) — high: exponential parsing time in flow collections (DoS). Patched `>=5.2.2` | `@nestjs/swagger` declares `"js-yaml": "5.2.1"` — an **exact pin**, the same shape as the `ws` case. It cannot resolve forward |
 
 `@nestjs/graphql` is a plain `dependencies` entry, so `ws` is installed even when you run with
-`graphQl: false`. Neither package is optional in practice.
+`graphQl: false`. `@nestjs/swagger` is likewise a plain `dependencies` entry. None of the three is
+optional in practice.
 
 ## The fix
 
@@ -40,6 +42,11 @@ overrides:
   # `(fetchCallback, options?)` is unchanged in 2.x. Engines >=20 and peer hono@^4 both fit.
   # Remove once @modelcontextprotocol/sdk moves its own range to ^2.
   '@hono/node-server@<2.0.10': '2.0.11'
+
+  # @nestjs/swagger exact-pins js-yaml@5.2.1 (GHSA-pm4m-ph32-ghv5, high, patched >=5.2.2).
+  # Same shape as the ws entry: an exact pin cannot resolve forward.
+  # Remove once @nestjs/swagger stops pinning it.
+  'js-yaml@>=5.0.0 <5.2.2': '5.2.2'
 ```
 
 Then:

--- a/migration-guides/11.32.3-to-11.32.4.md
+++ b/migration-guides/11.32.3-to-11.32.4.md
@@ -1,0 +1,323 @@
+# Migration Guide: 11.32.3 → 11.32.4
+
+## Overview
+
+| Category | Details |
+|----------|---------|
+| **Breaking Changes** | None in signatures. Six **runtime behaviour** changes you inherit automatically — see §1, §2, §4, §5, §6, §7 |
+| **New Features** | `assertGridFsFileComplete()` — verify a stored GridFS file's chunk completeness; `UploadAllowList` — exact-matching upload filters, with `SCRIPTABLE_UPLOAD_MIME_TYPES` / `SCRIPTABLE_UPLOAD_EXTENSIONS` and the `allowScriptableTypes` opt-out |
+| **Bugfixes** | GridFS uploads no longer report success for incomplete files, no longer hang on an unreadable source, and no longer leak their connection; file downloads answer an honest 404 instead of dropping the socket; the migrate CLI now actually terminates and no longer truncates its own output; the upload filter no longer matches mimetypes and extensions as SUBSTRINGS (`te?xt` accepted `text/html`), no longer reports rejections as a bare string, and `multerOptionsForImageUpload` no longer silently disables all filtering when `fileTypeRegex` is `undefined` |
+| **Migration Effort** | No code changes for most projects, and nothing to configure. Read §1 if you have seed migrations that upload assets, §4 if any test asserts on download error messages, §5–§7 if your project accepts uploads |
+
+---
+
+## Quick Migration
+
+```bash
+pnpm update @lenne.tech/nest-server@11.32.4
+pnpm run build
+pnpm test
+```
+
+No configuration change is required. Existing `fileTypeRegex` arguments keep working.
+
+**Vendor-mode projects:** four modified files under `src/core/`
+(`common/helpers/file.helper.ts`, `modules/file/core-file.controller.ts`,
+`modules/migrate/cli/migrate-cli.ts`, `modules/migrate/helpers/migration.helper.ts`) plus
+`bin/migrate.js`. No moved files — there is no atomic file-set hazard for a partial sync.
+
+---
+
+## 1. `uploadFileToGridFS()` now fails loudly instead of quietly
+
+Previously the helper resolved as soon as the write stream emitted `'finish'`. That event says the
+stream ended — it does **not** prove every chunk document is durably stored. A connection lost at the
+wrong moment left a files document promising more bytes than existed, the migration reported success,
+and the defect surfaced much later as a broken download from a record that looked perfectly healthy.
+
+It now verifies chunk completeness before resolving, and **rejects** when the file is incomplete
+(removing the incomplete file so retries do not accumulate orphans).
+
+**What you may notice:** a seed migration that previously "succeeded" while silently storing a broken
+asset now fails. Since `docker-entrypoint.sh` defaults to `MIGRATE_FAILURE_POLICY=abort`, that failure
+keeps the container from starting.
+
+**This is intentional** — finding exactly this is why migrations run before the server. To recover:
+
+```bash
+# 1. Identify the incomplete file from the migration error, which names it:
+#    GridFS file 'logo.png' is incomplete: 1 of 3 chunks stored (id 6a6b…)
+# 2. Verify the source asset is actually present and readable in the image/checkout.
+# 3. Re-run. The helper deletes its own incomplete upload, but a file left behind by
+#    an OLDER version of the helper must be removed manually:
+#      db.getCollection('<bucket>.files').deleteOne({ _id: ObjectId('…') })
+#      db.getCollection('<bucket>.chunks').deleteMany({ files_id: ObjectId('…') })
+```
+
+Two more changes to the same helper, both strictly better and requiring no action:
+
+- **An unreadable source rejects instead of hanging.** `pipe()` does not forward read-stream errors,
+  so a missing file used to leave the promise pending forever — a migration that never returned.
+  It now rejects with the underlying `ENOENT`.
+- **The connection is always closed.** The client it opens is registered and closed on every path.
+  A leaked client keeps an SDAM monitor timer alive, which kept the whole CLI from exiting.
+
+**Note on empty files:** GridFS stores a zero-byte file with **no** chunk documents at all, and the
+completeness check accounts for that. Uploading an empty placeholder asset is valid and passes.
+
+---
+
+## 2. `migrate up` now terminates explicitly
+
+The CLI drains stdout/stderr and then exits, instead of waiting for the event loop to empty. A single
+handle left behind by MongoDB, GridFS or the state store used to keep the process alive after the work
+was done: the CLI printed "All migrations completed successfully" and never returned. On a developer
+machine that is invisible; in CI the job blocks until its timeout, and a container that runs
+migrations before starting the server never reaches the server at all.
+
+Exit codes are unchanged (`0` success, `1` failure), and the drain happens **before** the exit, so no
+output is lost — `process.exit()` does not flush an asynchronous pipe, which is exactly what Docker's
+log driver and CI log collectors are.
+
+**Action required: none**, unless you invoke the CLI in a non-standard way. If you call the CLI
+module directly rather than through the `migrate` / `nest-migrate` bin, use the new exported
+`runCli()` (which drains and exits) instead of `main()` (which merely resolves):
+
+```typescript
+// Before — resolves, but relies on the event loop draining by itself
+const { main } = require('@lenne.tech/nest-server/dist/core/modules/migrate/cli/migrate-cli');
+main();
+
+// After
+const { runCli } = require('@lenne.tech/nest-server/dist/core/modules/migrate/cli/migrate-cli');
+void runCli();
+```
+
+The shipped `bin/migrate.js` already prefers `runCli()` and falls back to `main()`, so a mixed
+version pair keeps working.
+
+---
+
+## 3. New: `assertGridFsFileComplete()`
+
+Exported for direct use when you need to check a file that something else wrote — a restored dump,
+another service, a manual upload:
+
+```typescript
+import { assertGridFsFileComplete, getDb } from '@lenne.tech/nest-server';
+
+const db = await getDb(process.env.MONGODB_URL);
+await assertGridFsFileComplete(db, 'images', fileId, 'logo.png'); // throws if incomplete
+```
+
+It counts chunk documents rather than reading bytes back, so a chunk that was written but truncated
+is not detected. See `src/core/modules/migrate/README.md`.
+
+---
+
+## 4. File downloads: error responses changed
+
+Two changes on `GET /files/id/:id` and `GET /files/:filename`.
+
+**(a) A GridFS read error is now a 404, not a dropped socket.** The stream error previously went
+unhandled, Node destroyed the socket mid-response, and a reverse proxy turned that into
+**502 Bad Gateway** — reading as "the server is down" while every other route answered normally.
+The response is now:
+
+```json
+{ "error": "Not Found", "message": "#LTNS_0500: File not found", "statusCode": 404 }
+```
+
+Once bytes are already on the wire there is no status left to send, so the connection is still closed
+— at that point it genuinely is a truncated transfer.
+
+**(b) Exception messages now carry their ErrorCode.** The controller uses the framework registry
+instead of raw strings, matching every other core module:
+
+| Before | After |
+|--------|-------|
+| `'File not found'` | `ErrorCode.FILE_NOT_FOUND` → `'#LTNS_0500: File not found'` |
+| `'Missing file ID for download'` | `ErrorCode.REQUIRED_FIELD_MISSING` → `'#LTNS_0301: Required field missing'` |
+
+**Action required:** if a test asserts on the exact message, loosen it to a substring match — the old
+text is still contained in the new one. Frontends using `useLtErrorTranslation()` gain a translated
+message where they previously showed raw English.
+
+**Also:** a project that restricted downloads by overriding `CoreFileService.checkRights()` used to
+get a **500** (the refusal produced `null.pipe(res)` → `TypeError`). It is now a **404** —
+deliberately the same answer as an unknown id, so the endpoint cannot be used to probe which files
+exist.
+
+To customise the status, body or logging of the streaming error path, override the new
+`protected pipeFileToResponse()` method on your controller:
+
+```typescript
+export class FileController extends CoreFileController {
+  protected override pipeFileToResponse(stream: Readable, res: Response): Response {
+    // e.g. report a different status, or add your own telemetry
+    return super.pipeFileToResponse(stream, res);
+  }
+}
+```
+
+---
+
+## 5. The upload filter matched substrings, not values
+
+**What changed:** `multerFileFilter` compared the mimetype and the extension by
+`RegExp.test()` — a substring search. Every alternative therefore matched
+anywhere inside either value.
+
+**Why it matters:** an allow-list containing `text` or `txt` also accepted
+`text/html` and `text/xml`. A file named `x.txt` and sent as `text/html` passed
+both halves of a filter whose own comment said "no html". `md` matched every
+mimetype containing "md", `zip` every one containing "zip". The single
+alternative was never the bug — the substring semantics were.
+
+Anchoring the expression was not an option: the SAME expression was tested
+against two different value spaces, so it had to carry mimetype FRAGMENTS
+(`wordprocessingml`, `ms-excel`) next to bare extensions, and no `^…$` satisfies
+both at once.
+
+**What to do:** nothing, if your filter only ever listed image formats — those
+never matched markup. If your filter lists text-ish or document formats, move to
+the new exact-matching form:
+
+```ts
+// Before — substring matching
+multerOptionsForImageUpload({ fileTypeRegex: /jpeg|jpg|png|pdf|te?xt|csv/ });
+
+// After — whole-value matching
+multerOptionsForImageUpload({
+  allowList: {
+    extensions: ['.csv', '.jpeg', '.jpg', '.pdf', '.png', '.txt'],
+    mimeTypes: ['application/pdf', 'image/jpeg', 'image/png', 'text/csv', 'text/plain'],
+  },
+});
+```
+
+The two conditions stay **independent**: either one alone rejects the file, but a
+pair that is odd yet individually allowed (`report.txt` announced as
+`application/pdf`) passes. An extension→mimetype MAPPING is deliberately not
+enforced — user agents genuinely disagree about office and audio types (macOS
+reports `.csv` as `text/plain`), so a mapping rejects legitimate uploads.
+
+`fileTypeRegex` still works and is not removed; it is marked deprecated.
+
+---
+
+## 6. Scriptable types are now rejected on BOTH forms
+
+**What changed:** `text/html`, `text/xml`, `application/xhtml+xml`,
+`image/svg+xml`, JavaScript types and the matching extensions (`.html`, `.svg`,
+`.js`, `.xml`, …) are rejected before the allow-list is consulted — including
+when a legacy `fileTypeRegex` would have matched them.
+
+**Why it matters:** this is what closes §5 for expressions that already exist in
+consumer projects, without anyone having to rewrite them. The danger does not
+depend on what an endpoint meant to accept: a stored upload served back from the
+API origin with one of these content types executes in that origin, with the
+victim's session.
+
+**What to do:** if you deliberately accept SVG logos or HTML fragments, opt out
+explicitly:
+
+```ts
+multerFileFilter(
+  { extensions: ['.svg'], mimeTypes: ['image/svg+xml'] },
+  { allowScriptableTypes: true },
+);
+```
+
+Only do that when the file is never served from an origin that carries a session
+— e.g. a separate download host, or a route that always answers with
+`Content-Disposition: attachment` **and** `X-Content-Type-Options: nosniff`.
+
+---
+
+## 7. `fileTypeRegex: undefined` no longer disables filtering
+
+**What changed:** `multerOptionsForImageUpload` built its config as
+`{ fileTypeRegex: /jpeg|jpg|png/, ...options }` and then installed a filter only
+`if (config.fileTypeRegex)`. Passing the key explicitly as `undefined`
+overwrote the default, so **no filter was installed at all** and every file type
+was accepted — on a helper named "ImageUpload".
+
+**Why it matters:** this is easy to trigger by accident rather than intent:
+
+```ts
+// The author meant "then just the standard image types".
+// Before: they got "then everything".
+multerOptionsForImageUpload({ fileTypeRegex: allowSvg ? /jpeg|jpg|png|svg/ : undefined });
+```
+
+Any optional variable threaded into that option had the same effect.
+
+**What to do:** if a project relied on this to accept arbitrary types, it now
+gets JPEG/PNG only and those uploads start failing. Pass an explicit `allowList`
+naming what the endpoint really accepts. There is intentionally no "accept
+everything" switch — an upload endpoint that takes any type should not be built
+on `multerOptionsForImageUpload`.
+
+---
+
+## 8. Upload rejections are a real `Error`
+
+**What changed:** the filter called `cb('Error: File upload only supports …')`
+with a bare **string**. It now passes an `Error`.
+
+**Why it matters:** a string has no `message`, so NestJS's `transformException`
+could not map it and the request surfaced as a 500 instead of a 4xx.
+
+**What to do:** nothing, unless a test asserts on the exact error value. Assert
+on `error.message` instead.
+
+---
+
+## 9. Dependency housekeeping (no action required)
+
+- `js-yaml` gained an override for [GHSA-pm4m-ph32-ghv5](https://github.com/advisories/GHSA-pm4m-ph32-ghv5)
+  (high). **`@nestjs/swagger` exact-pins `js-yaml@5.2.1`, so your project needs this override too** —
+  a framework override does not reach consumer trees. See
+  [`docs/security-overrides.md`](../docs/security-overrides.md), which now lists all three affected
+  packages.
+- The `minimatch` override range was narrowed to `>=9.0.0`; majors 5–8 export a callable function and
+  would break under a forced lift to 10.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Migration now fails with `is incomplete: N of M chunks stored` | The asset was already broken in the database; the old helper never checked | See §1 — verify the source asset, remove the orphan, re-run |
+| Migration now fails with `ENOENT` | The source path was always wrong; it used to hang instead of failing | Fix the path. It is resolved against the **helper module's** directory |
+| A test asserting `'File not found'` fails | The message now carries its ErrorCode prefix | Match on a substring, or on `ErrorCode.FILE_NOT_FOUND` |
+| A download that returned 500 now returns 404 | `checkRights()` refusal is handled properly instead of crashing | Intended — see §4 |
+| An upload fails with `may execute as script` | The type is markup or script and is now rejected regardless of the filter | Intended — see §6, and opt out only under the conditions named there |
+| An upload of a document type that used to pass now fails | The filter matched it as a substring before | Move to `allowList` naming the type exactly — see §5 |
+| Uploads that accepted every type now accept JPEG/PNG only | `fileTypeRegex: undefined` no longer disables the filter | Pass an explicit `allowList` — see §7 |
+| A test asserting on the filter's rejection string fails | Rejections are an `Error` now, not a string | Assert on `error.message` — see §8 |
+
+---
+
+## Verification
+
+```bash
+pnpm test
+```
+
+`src/core/common/helpers/file.helper.spec.ts` covers the substring class (values that merely CONTAIN
+an allowed token), the scriptable-type rejection on both forms, the opt-out, and that the legacy
+`RegExp` form still accepts what it accepted before.
+`src/core/modules/migrate/helpers/migration.helper.spec.ts` and
+`tests/migrate/upload-file-to-gridfs.e2e-spec.ts` cover the completeness check against a real GridFS
+bucket; `src/core/modules/file/core-file.controller.spec.ts` covers the download error paths.
+
+---
+
+## Related Documentation
+
+- [`src/core/modules/migrate/README.md`](../src/core/modules/migrate/README.md) — `uploadFileToGridFS()`, `assertGridFsFileComplete()`
+- [`src/core/modules/file/README.md`](../src/core/modules/file/README.md) — download endpoints, error responses
+- [`docs/security-overrides.md`](../docs/security-overrides.md) — overrides consumers must replicate

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lenne.tech/nest-server",
-  "version": "11.32.3",
+  "version": "11.32.4",
   "description": "Modern, fast, powerful Node.js web framework in TypeScript based on Nest with a GraphQL API and a connection to MongoDB (or other databases).",
   "keywords": [
     "node",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,12 @@ settings:
 overrides:
   ws@>=8.0.0 <8.21.0: 8.21.1
   axios@<1.18.0: 1.18.1
-  brace-expansion@>=5.0.0 <5.0.7: 5.0.7
+  brace-expansion@>=5.0.0 <5.0.8: 5.0.8
   brace-expansion@>=2.0.0 <2.1.2: 2.1.2
   brace-expansion@<1.1.16: 1.1.16
+  minimatch@>=9.0.0 <10.2.6: 10.2.6
   js-yaml@>=4.0.0 <4.3.0: 4.3.0
+  js-yaml@>=5.0.0 <5.2.2: 5.2.2
   fast-uri@>=3.0.0 <3.1.4: 3.1.4
   body-parser@>=2.0.0 <2.3.0: 2.3.0
   '@hono/node-server@<2.0.10': 2.0.11
@@ -2481,12 +2483,9 @@ packages:
   brace-expansion@1.1.16:
     resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
-
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -3545,8 +3544,8 @@ packages:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
-  js-yaml@5.2.1:
-    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
+  js-yaml@5.2.2:
+    resolution: {integrity: sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==}
     hasBin: true
 
   json-bigint@1.0.0:
@@ -3896,16 +3895,12 @@ packages:
     resolution: {integrity: sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  minimatch@10.2.5:
-    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
     engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
-
-  minimatch@9.0.9:
-    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
-    engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -6108,7 +6103,7 @@ snapshots:
       '@nestjs/common': 11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.28(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.28)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/mapped-types': 2.1.1(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
-      js-yaml: 5.2.1
+      js-yaml: 5.2.2
       lodash: 4.18.1
       path-to-regexp: 8.4.2
       reflect-metadata: 0.2.2
@@ -6491,7 +6486,7 @@ snapshots:
       '@swc/counter': 0.1.3
       '@xhmikosr/bin-wrapper': 14.2.2
       commander: 8.3.0
-      minimatch: 9.0.9
+      minimatch: 10.2.6
       piscina: 4.9.3
       semver: 7.7.4
       slash: 3.0.0
@@ -6581,7 +6576,7 @@ snapshots:
 
   '@ts-morph/common@0.29.0':
     dependencies:
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       path-browserify: 1.0.1
       tinyglobby: 0.2.17
 
@@ -7240,11 +7235,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
-    dependencies:
-      balanced-match: 1.0.2
-
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -8016,7 +8007,7 @@ snapshots:
 
   glob@13.0.6:
     dependencies:
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       minipass: 7.1.3
       path-scurry: 2.0.2
 
@@ -8301,7 +8292,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  js-yaml@5.2.1:
+  js-yaml@5.2.2:
     dependencies:
       argparse: 2.0.1
 
@@ -8579,17 +8570,13 @@ snapshots:
 
   mimic-response@4.0.0: {}
 
-  minimatch@10.2.5:
+  minimatch@10.2.6:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.16
-
-  minimatch@9.0.9:
-    dependencies:
-      brace-expansion: 2.1.2
 
   minimist@1.2.8: {}
 
@@ -8683,7 +8670,7 @@ snapshots:
       chokidar: 3.6.0
       debug: 4.4.3(supports-color@5.5.0)
       ignore-by-default: 1.0.1
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       pstree.remy: 1.1.8
       semver: 7.7.4
       simple-update-notifier: 2.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,31 @@ allowBuilds:
   '@apollo/protobufjs': true
   '@scarf/scarf': false
 
+# ----------------------------------------------------------------------------------
+# Advisories we knowingly do NOT fix, with the reason. `pnpm audit` treats these as
+# resolved, so the CI gate stays meaningful for everything else.
+# Rules for adding one: name the advisory, say why it cannot be fixed, say why the
+# residual risk is acceptable, and date the verification. If you cannot write those
+# three sentences honestly, fix the dependency instead.
+# ----------------------------------------------------------------------------------
+auditConfig:
+  ignoreGhsas:
+    # brace-expansion DoS via unbounded expansion (HIGH). Patched ONLY in 5.0.8 — verified
+    # 2026-07-28 that neither 1.1.16 nor 2.1.2 contains a length guard, so there is no 1.x
+    # backport to move to. After the `minimatch@>=5.0.0 <10.2.6 -> 10.2.6` override above
+    # (10.2.6 requests the patched ^5.0.8) exactly ONE path remains:
+    #   @nestjs/cli > fork-ts-checker-webpack-plugin > minimatch@3 > brace-expansion@1
+    # Not fixable: fork-ts-checker calls `__importDefault(require('minimatch')).default(...)`.
+    # minimatch@10 sets `__esModule: true` without a `.default`, so substituting it throws
+    # "minimatch_1.default is not a function"; forcing brace-expansion@5.0.8 under minimatch@3
+    # throws "expand is not a function". Both reproduced 2026-07-28.
+    # Residual accepted: dev-only build tooling, running on a developer machine or CI runner
+    # over repo-local input. It is not a dependency of the published package (`files` ships
+    # dist + docs only), so no consumer and no runtime ever reaches this code.
+    # Re-verify when @nestjs/cli drops fork-ts-checker-webpack-plugin — then delete this entry.
+    # Verified 2026-07-28 (DEV-2698).
+    - GHSA-mh99-v99m-4gvg
+
 peerDependencyRules:
   allowedVersions:
     '@apollo/server': '5'
@@ -56,17 +81,37 @@ overrides:
   # Security: Axios formDataToJSON recursion DoS + prototype pollution in auth subfields (3x moderate, patched >=1.18.0) - transitive via node-mailjet>axios (@getbrevo/brevo dropped all runtime deps in v6)
   # Inert today (axios already resolves >=1.18.0). Remove once node-mailjet requests >=1.18.0 itself.
   'axios@<1.18.0': '1.18.1'
-  # Security: brace-expansion DoS via exponential-time expansion of consecutive non-expanding {} groups (GHSA-3jxr-9vmj-r5cp, high) - one entry per affected major, each a patch bump INSIDE that major.
+  # Security: brace-expansion DoS - two advisories. GHSA-3jxr-9vmj-r5cp (exponential-time expansion of
+  # consecutive non-expanding {} groups) and GHSA-mh99-v99m-4gvg (unbounded expansion length -> OOM,
+  # patched ONLY in 5.0.8; verified 2026-07-28 that 1.1.16 and 2.1.2 carry no length guard at all).
+  # One entry per affected major, each a patch bump INSIDE that major.
   # v5 (prod): ts-morph>@ts-morph/common>minimatch, directly and via @nestjs/graphql + @nestjs/apollo. v2/v1 (dev only): @nestjs/cli + @swc/cli > minimatch, @nestjs/cli>fork-ts-checker-webpack-plugin>minimatch.
   # The v5 key is floored at >=5.0.0 on purpose: a wider `>=3.0.0` would ALSO match a future 3.x/4.x
   # dependency and silently force it across two majors - which is not what "patch bump" means.
   # Inert today (all three resolve patched). Remove once minimatch requests the patched ranges.
-  'brace-expansion@>=5.0.0 <5.0.7': '5.0.7'
+  'brace-expansion@>=5.0.0 <5.0.8': '5.0.8'
+  # The 2.x line no longer resolves at all since the minimatch lift below removed its only parent.
+  # Kept anyway, and deliberately: it is not inert because the dependency was fixed, but because
+  # ANOTHER override happens to hide it. Drop the minimatch entry and 2.x returns immediately, so
+  # deleting this one would couple two unrelated lines. Remove it once minimatch@9 is gone for good.
   'brace-expansion@>=2.0.0 <2.1.2': '2.1.2'
   'brace-expansion@<1.1.16': '1.1.16'
+  # Security: the real lever for GHSA-mh99-v99m-4gvg. Only brace-expansion 5.0.8 carries the fix, and
+  # forcing it onto a minimatch@3 consumer throws "expand is not a function" (5.x exports a namespace
+  # object, not a callable). minimatch 10.2.6 REQUESTS ^5.0.8, so lifting every 9.x consumer onto it
+  # removes the vulnerable 2.x line from the tree legitimately.
+  # Floored at >=9.0.0, NOT >=5.0.0: only 9 and 10 share the non-callable CJS export shape. Verified
+  # 2026-07-30 that majors 5-8 export a CALLABLE function (5.1.6: `typeof m === 'function'`; 6-8 add a
+  # `.default`), so forcing them onto 10 would throw the very "is not a function" documented below as
+  # the reason minimatch@3 is excluded. Nothing resolves in 5-8 today, so the wider floor was latent
+  # rather than broken - but it pre-authorized exactly the break it warns about.
+  # minimatch@3 is deliberately NOT matched - see auditConfig above.
+  'minimatch@>=9.0.0 <10.2.6': '10.2.6'
   # Security: js-yaml quadratic CPU consumption via YAML merge-key chains (GHSA-52cp-r559-cp3m, high, patched >=4.3.0) - dev only, transitive via @compodoc/compodoc>cosmiconfig and @nestjs/cli>fork-ts-checker-webpack-plugin>cosmiconfig
   # Inert today. Remove once cosmiconfig requests >=4.3.0.
   'js-yaml@>=4.0.0 <4.3.0': '4.3.0'
+  # Security: js-yaml exponential parsing time in flow collections (GHSA-pm4m-ph32-ghv5, high, patched >=5.2.2) - transitive via @nestjs/swagger>js-yaml. Separate line from the 4.x entry above: same package, different major.
+  'js-yaml@>=5.0.0 <5.2.2': '5.2.2'
   # Security: fast-uri host confusion via failed IDN canonicalization (GHSA-v2hh-gcrm-f6hx, high, patched >=3.1.3) and via literal backslash authority delimiter (high, patched >=3.1.4) - transitive via @modelcontextprotocol/sdk>ajv and @modelcontextprotocol/sdk>ajv-formats>ajv
   # Inert today. Remove once ajv / ajv-formats request >=3.1.4.
   'fast-uri@>=3.0.0 <3.1.4': '3.1.4'

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -191,8 +191,25 @@ async function runAudit(auditCmd) {
   const cmd = /(^|\s)--json(\s|$)/.test(auditCmd) ? auditCmd : `${auditCmd} --json`;
   const { code, out } = await capture(cmd, ROOT);
   let counts = null;
+  let ignored = 0;
   try {
-    counts = JSON.parse(out.slice(out.indexOf('{')))?.metadata?.vulnerabilities ?? null;
+    const parsed = JSON.parse(out.slice(out.indexOf('{')));
+    // `metadata.vulnerabilities` is the RAW tally — pnpm deliberately leaves it
+    // unfiltered so it can report "(N ignored)" separately. `advisories` is the
+    // filtered set, i.e. what `auditConfig.ignoreGhsas` did NOT suppress.
+    // Reporting the raw tally would print a green check next to "high 1", which
+    // reads as an unaddressed finding and trains the reader to ignore the number.
+    const raw = parsed?.metadata?.vulnerabilities ?? null;
+    const advisories = Object.values(parsed?.advisories ?? {});
+    if (raw) {
+      counts = { critical: 0, high: 0, info: 0, low: 0, moderate: 0 };
+      for (const advisory of advisories) {
+        if (advisory?.severity in counts) {
+          counts[advisory.severity] += 1;
+        }
+      }
+      ignored = Math.max(0, SEVERITIES.reduce((n, s) => n + (raw[s] || 0), 0) - advisories.length);
+    }
   } catch {
     /* fall through to raw reason */
   }
@@ -200,7 +217,15 @@ async function runAudit(auditCmd) {
   // Non-zero exit with no parseable counts AND the retired-endpoint signature = infrastructure
   // failure, not a finding. Surface it loudly (degraded) but do not block.
   const degraded = code !== 0 && !counts && isAuditEndpointUnavailable(out);
-  return { auditCmd, blocking: code !== 0 && !degraded, counts, degraded, reason: counts ? null : out, total };
+  return {
+    auditCmd,
+    blocking: code !== 0 && !degraded,
+    counts,
+    degraded,
+    ignored,
+    reason: counts ? null : out,
+    total,
+  };
 }
 
 // ── command runner ─────────────────────────────────────────────────────────
@@ -555,9 +580,13 @@ async function main() {
     const dur = Date.now() - t;
     if (audit.blocking) {
       liveCount = 0; // the failure line must survive — nothing may overwrite it
-      const summary = audit.counts ? `${audit.total} vuln (${renderVulnLine(audit.counts)})` : 'failed';
+      const summary = audit.counts ? `${audit.total} vuln (${renderVulnLine(audit.counts, audit.ignored)})` : 'failed';
       console.log(`${C.red('✗')} audit  ${C.red(summary)} ${C.dim(`(${fmtDuration(dur)})`)}`);
-      return fail(`audit (${auditCmd})`, audit.counts ? renderVulnLine(audit.counts) : audit.reason, started);
+      return fail(
+        `audit (${auditCmd})`,
+        audit.counts ? renderVulnLine(audit.counts, audit.ignored) : audit.reason,
+        started,
+      );
     }
     if (audit.degraded) {
       // Not green: audit could not run. Yellow ⚠, never a green ✓ — a ✓ here would read as
@@ -568,7 +597,7 @@ async function main() {
       );
     } else if (!TTY) {
       process.stdout.write(
-        `  ${C.green('✓')} audit  ${audit.counts ? renderVulnLine(audit.counts) : C.dim('0')} ${C.dim(`(${fmtDuration(dur)})`)}\n`,
+        `  ${C.green('✓')} audit  ${audit.counts ? renderVulnLine(audit.counts, audit.ignored) : C.dim('0')} ${C.dim(`(${fmtDuration(dur)})`)}\n`,
       );
     }
     // TTY success: NO permanent line — the live status view overwrites the audit
@@ -604,13 +633,16 @@ async function main() {
 }
 
 // ── rendering helpers ─────────────────────────────────────────────────────────
-function renderVulnLine(counts) {
-  return SEVERITIES.map((s) => {
+function renderVulnLine(counts, ignored = 0) {
+  const line = SEVERITIES.map((s) => {
     const n = counts[s] || 0;
     const txt = `${s} ${n}`;
     if (n > 0 && (s === 'critical' || s === 'high')) return C.red(txt);
     return n > 0 ? C.yellow(txt) : C.dim(txt);
   }).join(C.dim(' · '));
+  // Never hide a suppression: a silently filtered advisory is indistinguishable
+  // from one that never existed, which is exactly what makes `ignoreGhsas` risky.
+  return ignored > 0 ? `${line}${C.dim(' · ')}${C.yellow(`${ignored} ignored`)}` : line;
 }
 
 function metricSuffix(r) {
@@ -677,7 +709,7 @@ function report(started, results) {
   console.log(
     `  ${
       audit?.counts
-        ? renderVulnLine(audit.counts)
+        ? renderVulnLine(audit.counts, audit.ignored)
         : audit?.degraded
           ? C.yellow('audit could not run (npm retired the endpoint pnpm uses) — vulnerabilities NOT checked')
           : C.dim(audit ? 'counts unavailable' : '—')

--- a/spectaql.yml
+++ b/spectaql.yml
@@ -19,7 +19,7 @@ servers:
 info:
   title: lT Nest Server
   description: Modern, fast, powerful Node.js web framework in TypeScript based on Nest with a GraphQL API and a connection to MongoDB (or other databases).
-  version: 11.32.3
+  version: 11.32.4
   contact:
     name: lenne.Tech GmbH
     url: https://lenne.tech

--- a/src/core/common/helpers/file.helper.spec.ts
+++ b/src/core/common/helpers/file.helper.spec.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+
+import { IMAGE_UPLOAD_ALLOW_LIST, multerFileFilter, multerOptionsForImageUpload, UploadAllowList } from './file.helper';
+
+/**
+ * The filter used to be ONE unanchored `RegExp`, `.test()`ed against the
+ * mimetype AND the extension. `.test()` searches for a substring, so every
+ * alternative matched anywhere inside either value — `te?xt` matched the "text"
+ * in `text/html`, and a file named `x.txt` sent as `text/html` passed both
+ * halves of a filter documented as "no html".
+ *
+ * Consumer projects hit this for real. The tests below therefore cover three
+ * things: the exact-matching allow-list, that the legacy `RegExp` form still
+ * works, and — the point of the fix — that scriptable types are rejected on
+ * BOTH paths, so an expression that already exists in a consumer project is
+ * safe without being rewritten.
+ */
+
+/** Run a filter the way multer does and report its verdict. */
+function verdict(
+  filter: ReturnType<typeof multerFileFilter>,
+  mimetype: string,
+  originalname: string,
+): { accepted: boolean; error?: string } {
+  let accepted = false;
+  let error: string | undefined;
+  filter({}, { mimetype, originalname }, (err: any, result?: boolean) => {
+    if (err) {
+      error = err instanceof Error ? err.message : String(err);
+    }
+    accepted = result === true;
+  });
+  return { accepted, error };
+}
+
+const DOCUMENTS: UploadAllowList = {
+  extensions: ['.csv', '.pdf', '.txt'],
+  mimeTypes: ['application/pdf', 'text/csv', 'text/plain'],
+};
+
+describe('multerFileFilter', () => {
+  describe('allow-list form', () => {
+    it('accepts a mimetype and extension that are both on the list', () => {
+      expect(verdict(multerFileFilter(DOCUMENTS), 'text/plain', 'notes.txt').accepted).toBe(true);
+      expect(verdict(multerFileFilter(DOCUMENTS), 'application/pdf', 'report.pdf').accepted).toBe(true);
+    });
+
+    it('rejects as soon as one half is missing from the list', () => {
+      expect(verdict(multerFileFilter(DOCUMENTS), 'application/x-msdownload', 'setup.pdf').accepted).toBe(false);
+      expect(verdict(multerFileFilter(DOCUMENTS), 'application/pdf', 'setup.exe').accepted).toBe(false);
+    });
+
+    it('matches whole values, never substrings', () => {
+      // Only an unanchored matcher would let these through.
+      expect(verdict(multerFileFilter(DOCUMENTS), 'evil/text-plain', 'notes.txt').accepted).toBe(false);
+      expect(verdict(multerFileFilter(DOCUMENTS), 'text/plain', 'notes.txtx').accepted).toBe(false);
+    });
+
+    it('ignores mimetype parameters and casing', () => {
+      expect(verdict(multerFileFilter(DOCUMENTS), 'text/plain; charset=utf-8', 'notes.txt').accepted).toBe(true);
+      expect(verdict(multerFileFilter(IMAGE_UPLOAD_ALLOW_LIST), 'IMAGE/PNG', 'PHOTO.PNG').accepted).toBe(true);
+    });
+
+    it('rejects a file without an extension', () => {
+      expect(verdict(multerFileFilter(DOCUMENTS), 'text/plain', 'README').accepted).toBe(false);
+    });
+  });
+
+  describe('scriptable types are rejected on BOTH forms', () => {
+    // This is what makes an ALREADY EXISTING consumer expression safe.
+    const legacy = /jpeg|jpg|png|te?xt|csv/;
+
+    it('rejects text/html even when the expression matches it as a substring', () => {
+      const result = verdict(multerFileFilter(legacy), 'text/html', 'invoice.txt');
+      expect(result.accepted).toBe(false);
+      expect(result.error).toMatch(/may execute as script/);
+    });
+
+    it('rejects text/xml and application/xhtml+xml', () => {
+      expect(verdict(multerFileFilter(legacy), 'text/xml', 'notes.txt').accepted).toBe(false);
+      expect(verdict(multerFileFilter(legacy), 'application/xhtml+xml', 'notes.txt').accepted).toBe(false);
+    });
+
+    it('rejects SVG on the image default', () => {
+      expect(verdict(multerFileFilter(), 'image/svg+xml', 'logo.svg').accepted).toBe(false);
+    });
+
+    it('rejects a scriptable EXTENSION even under a harmless mimetype', () => {
+      expect(verdict(multerFileFilter(legacy), 'text/plain', 'payload.html').accepted).toBe(false);
+      expect(verdict(multerFileFilter(legacy), 'image/png', 'payload.svg').accepted).toBe(false);
+    });
+
+    it('allows them only when the caller opts in explicitly', () => {
+      const filter = multerFileFilter(
+        { extensions: ['.svg'], mimeTypes: ['image/svg+xml'] },
+        {
+          allowScriptableTypes: true,
+        },
+      );
+      expect(verdict(filter, 'image/svg+xml', 'logo.svg').accepted).toBe(true);
+    });
+  });
+
+  describe('legacy RegExp form stays usable', () => {
+    it('still accepts what it accepted before', () => {
+      const filter = multerFileFilter(/jpeg|jpg|png/);
+      expect(verdict(filter, 'image/jpeg', 'photo.jpg').accepted).toBe(true);
+      expect(verdict(filter, 'image/png', 'photo.png').accepted).toBe(true);
+      expect(verdict(filter, 'application/pdf', 'report.pdf').accepted).toBe(false);
+    });
+  });
+
+  describe('rejection reporting', () => {
+    it('reports a real Error, not a bare string', () => {
+      let received: unknown;
+      multerFileFilter(DOCUMENTS)({}, { mimetype: 'application/x-foo', originalname: 'x.foo' }, (err: unknown) => {
+        received = err;
+      });
+      // A bare string leaves multer with an "error" that has no `message`,
+      // which NestJS's transformException cannot map to a 4xx.
+      expect(received).toBeInstanceOf(Error);
+    });
+  });
+});
+
+describe('multerOptionsForImageUpload', () => {
+  it('applies the image allow-list by default', () => {
+    const filter = multerOptionsForImageUpload({}).fileFilter!;
+    expect(verdict(filter as any, 'image/png', 'a.png').accepted).toBe(true);
+    expect(verdict(filter as any, 'image/svg+xml', 'a.svg').accepted).toBe(false);
+  });
+
+  it('still installs a filter when fileTypeRegex is explicitly undefined', () => {
+    // Previously this disabled filtering entirely — on a helper named
+    // "ImageUpload". Safe-by-default instead; see the migration guide.
+    const filter = multerOptionsForImageUpload({ fileTypeRegex: undefined }).fileFilter;
+    expect(filter).toBeDefined();
+    expect(verdict(filter as any, 'text/html', 'a.txt').accepted).toBe(false);
+  });
+
+  it('honours an explicit allowList', () => {
+    const filter = multerOptionsForImageUpload({ allowList: DOCUMENTS }).fileFilter!;
+    expect(verdict(filter as any, 'application/pdf', 'report.pdf').accepted).toBe(true);
+  });
+});

--- a/src/core/common/helpers/file.helper.ts
+++ b/src/core/common/helpers/file.helper.ts
@@ -3,6 +3,81 @@ import { diskStorage } from 'multer';
 import { extname } from 'path';
 
 /**
+ * What an upload endpoint accepts: exact mimetypes and exact file extensions.
+ *
+ * Prefer this over the legacy `RegExp` form. A single expression `.test()`ed
+ * against BOTH the mimetype and the extension searches for a SUBSTRING, so every
+ * alternative matches anywhere inside either value. An allow-list of `text` /
+ * `txt` therefore also accepts `text/html` and `text/xml`, and one containing
+ * `md` accepts every mimetype with "md" in it. Consumers hit this in practice:
+ * a filter documented as "no html" happily accepted a file named `x.txt` that
+ * was sent as `text/html`.
+ *
+ * Two separate sets also remove the reason the expression could not simply be
+ * anchored: it had to carry mimetype FRAGMENTS (`wordprocessingml`, `ms-excel`)
+ * next to bare extensions, and no anchoring satisfies both at once.
+ */
+export interface UploadAllowList {
+  /** Allowed file extensions, lowercase and WITH the leading dot. */
+  extensions: readonly string[];
+  /** Allowed mimetypes, lowercase and without parameters. */
+  mimeTypes: readonly string[];
+}
+
+/**
+ * Default for image uploads — the exact-matching equivalent of the legacy
+ * `/jpeg|jpg|png/`.
+ */
+export const IMAGE_UPLOAD_ALLOW_LIST: UploadAllowList = {
+  extensions: ['.jpeg', '.jpg', '.png'],
+  mimeTypes: ['image/jpeg', 'image/png'],
+};
+
+/**
+ * Types a browser may execute as script when it renders the stored file.
+ *
+ * These are rejected by {@link multerFileFilter} REGARDLESS of the allow-list,
+ * because the danger does not depend on what a given endpoint meant to accept:
+ * an upload served back from the API origin with one of these content types
+ * runs in that origin, with the victim's session. The check is what makes the
+ * legacy `RegExp` path safe for existing consumers without breaking their
+ * expressions — see `allowScriptableTypes` to opt out.
+ */
+export const SCRIPTABLE_UPLOAD_MIME_TYPES: readonly string[] = [
+  'application/javascript',
+  'application/xhtml+xml',
+  'application/xml',
+  'image/svg+xml',
+  'text/html',
+  'text/javascript',
+  'text/xml',
+];
+
+/** Extensions matching {@link SCRIPTABLE_UPLOAD_MIME_TYPES}. */
+export const SCRIPTABLE_UPLOAD_EXTENSIONS: readonly string[] = [
+  '.htm',
+  '.html',
+  '.js',
+  '.mjs',
+  '.svg',
+  '.xhtml',
+  '.xml',
+];
+
+/** Options for {@link multerFileFilter}. */
+export interface MulterFileFilterOptions {
+  /**
+   * Accept markup and script types too (`text/html`, `image/svg+xml`, …).
+   *
+   * Only set this when the stored file is never served from an origin that
+   * carries a session — e.g. a separate download host, or a route that always
+   * answers with `Content-Disposition: attachment` AND
+   * `X-Content-Type-Options: nosniff`.
+   */
+  allowScriptableTypes?: boolean;
+}
+
+/**
  * Helper class for inputs
  * @deprecated use functions directly
  */
@@ -18,14 +93,18 @@ export default class FileHelper {
   /**
    * Get function to filter files for multer with a certain mimetype & extname
    */
-  public static multerFileFilter(fileTypeRegex = /jpeg|jpg|png/) {
-    return multerFileFilter(fileTypeRegex);
+  public static multerFileFilter(
+    accept: RegExp | UploadAllowList = IMAGE_UPLOAD_ALLOW_LIST,
+    options?: MulterFileFilterOptions,
+  ) {
+    return multerFileFilter(accept, options);
   }
 
   /**
    * Get multer options for image upload
    */
   public static multerOptionsForImageUpload(options: {
+    allowList?: UploadAllowList;
     destination?: string;
     fileSize?: number;
     fileTypeRegex?: RegExp;
@@ -35,24 +114,80 @@ export default class FileHelper {
 }
 
 /**
- * Get function to filter files for multer with a certain mimetype & extname
+ * Reduce a reported mimetype to the bare type: lowercase, trimmed, without the
+ * `; charset=…` parameters a user agent may append.
  */
-export function multerFileFilter(fileTypeRegex = /jpeg|jpg|png/) {
-  return (req, file, cb) => {
-    const mimetype = fileTypeRegex.test(file.mimetype);
-    const extName = fileTypeRegex.test(extname(file.originalname).toLowerCase());
+function normalizeMimeType(value: string): string {
+  return String(value || '')
+    .split(';')[0]
+    .trim()
+    .toLowerCase();
+}
 
-    if (mimetype && extName) {
+/**
+ * Get a multer `fileFilter` that accepts only the given mimetypes / extensions.
+ *
+ * Pass an {@link UploadAllowList} — both the mimetype and the extension must
+ * appear in it, each compared as a WHOLE value. The two conditions are
+ * independent: either one alone rejects the file, while a pair that is odd yet
+ * individually allowed (`report.txt` announced as `application/pdf`) passes.
+ * An extension→mimetype MAPPING is deliberately not enforced: user agents
+ * genuinely disagree about office and audio types (macOS reports `.csv` as
+ * `text/plain`), so a mapping rejects legitimate uploads.
+ *
+ * A `RegExp` is still accepted for backwards compatibility but is
+ * **deprecated**: it is `.test()`ed against both values and therefore matches
+ * SUBSTRINGS, which is how `te?xt` ends up accepting `text/html`. Whichever form
+ * is used, the types in {@link SCRIPTABLE_UPLOAD_MIME_TYPES} /
+ * {@link SCRIPTABLE_UPLOAD_EXTENSIONS} are rejected first unless
+ * `options.allowScriptableTypes` is set — that is what closes the hole for
+ * expressions that already exist in consumer projects.
+ *
+ * Rejections are reported as a real `Error`. Passing a bare string (as this
+ * helper did before) leaves multer with an "error" that has no `message`, which
+ * NestJS's `transformException` cannot map to a 4xx.
+ */
+export function multerFileFilter(
+  accept: RegExp | UploadAllowList = IMAGE_UPLOAD_ALLOW_LIST,
+  options?: MulterFileFilterOptions,
+) {
+  return (req, file, cb) => {
+    const mimeType = normalizeMimeType(file?.mimetype);
+    const extension = extname(String(file?.originalname || '')).toLowerCase();
+
+    if (
+      !options?.allowScriptableTypes &&
+      (SCRIPTABLE_UPLOAD_MIME_TYPES.includes(mimeType) || SCRIPTABLE_UPLOAD_EXTENSIONS.includes(extension))
+    ) {
+      return cb(new Error(`File upload rejected: ${mimeType || 'unknown type'} may execute as script`));
+    }
+
+    const accepted =
+      accept instanceof RegExp
+        ? accept.test(mimeType) && accept.test(extension)
+        : accept.mimeTypes.includes(mimeType) && accept.extensions.includes(extension);
+
+    if (accepted) {
       return cb(null, true);
     }
-    cb(`Error: File upload only supports the following filetypes - ${fileTypeRegex}`);
+    cb(new Error(`File upload only supports the following filetypes - ${describeAccept(accept)}`));
   };
+}
+
+/** Render the accepted types for the rejection message. */
+function describeAccept(accept: RegExp | UploadAllowList): string {
+  return accept instanceof RegExp ? String(accept) : accept.extensions.join(', ');
 }
 
 /**
  * Get multer options for image upload
+ *
+ * Pass `allowList` for exact matching; `fileTypeRegex` is deprecated (see
+ * {@link multerFileFilter}). When neither is set, {@link IMAGE_UPLOAD_ALLOW_LIST}
+ * applies.
  */
 export function multerOptionsForImageUpload(options: {
+  allowList?: UploadAllowList;
   destination?: string;
   fileSize?: number;
   fileTypeRegex?: RegExp;
@@ -60,13 +195,16 @@ export function multerOptionsForImageUpload(options: {
   // Set config
   const config = {
     fileSize: 1024 * 1024, // 1MB
-    fileTypeRegex: /jpeg|jpg|png/, // Images only
     ...options,
   };
 
+  // An explicit regex keeps precedence so existing callers behave as before
+  // (minus the scriptable types); otherwise the exact-matching default applies.
+  const accept: RegExp | UploadAllowList = config.fileTypeRegex ?? config.allowList ?? IMAGE_UPLOAD_ALLOW_LIST;
+
   return {
     // File filter
-    fileFilter: config.fileTypeRegex ? multerFileFilter(config.fileTypeRegex) : undefined,
+    fileFilter: multerFileFilter(accept),
 
     // Limits
     limits: {

--- a/src/core/modules/file/README.md
+++ b/src/core/modules/file/README.md
@@ -74,6 +74,65 @@ export class FileController extends CoreFileController {
 }
 ```
 
+Access can also be restricted per file by overriding `CoreFileService.checkRights()`. When it
+refuses, `getFileStream()` returns `null` and the controller answers **404** — deliberately the same
+answer as an unknown id, so the endpoint cannot be used to probe which files exist. Do not change
+this to a 403 in an override without accepting that trade-off.
+
+### Error responses
+
+| Situation                                                                              | Status | Body                                                                                                  |
+| -------------------------------------------------------------------------------------- | ------ | ----------------------------------------------------------------------------------------------------- |
+| Unknown id / filename, or `checkRights()` refused                                      | `404`  | `NotFoundException` with `ErrorCode.FILE_NOT_FOUND`                                                   |
+| Missing id / filename in the route                                                     | `400`  | `BadRequestException` with `ErrorCode.REQUIRED_FIELD_MISSING`                                         |
+| GridFS read fails **before** any byte was sent (file document exists, chunks are gone) | `404`  | `{ "error": "Not Found", "message": "<FILE_NOT_FOUND>", "statusCode": 404 }`                          |
+| GridFS read fails **after** streaming started                                          | —      | The connection is closed; a truncated transfer is the only signal left once the status is on the wire |
+
+The mid-stream failure case is handled by `pipeFileToResponse()`. Without it the stream error would
+go unhandled, Node would destroy the socket, and a reverse proxy would report **502 Bad Gateway** —
+i.e. "the server is down", while every other route keeps answering. On the error path the headers
+describing the file (`Content-Type`, `Content-Disposition`, `Cache-Control`, `ETag`) are removed, so
+the JSON body is not labelled as the image it failed to deliver. The error itself is logged
+server-side even though the client answer stays deliberately generic.
+
+To change the status, the body or the logging, override the `protected pipeFileToResponse()` method
+on the controller rather than the exported function of the same name.
+
+### Upload filtering
+
+Upload endpoints are project-specific, but the filter they install comes from the framework
+(`multerOptionsForImageUpload()` / `multerFileFilter()` in `common/helpers/file.helper.ts`). Name what
+the endpoint accepts as an `UploadAllowList` — both the mimetype and the extension are compared as
+WHOLE values:
+
+```typescript
+@UseInterceptors(FileInterceptor('file', multerOptionsForImageUpload({
+  allowList: {
+    extensions: ['.jpeg', '.jpg', '.pdf', '.png'],
+    mimeTypes: ['application/pdf', 'image/jpeg', 'image/png'],
+  },
+})))
+```
+
+The two conditions are **independent**: either one alone rejects the file, while a pair that is odd
+yet individually allowed (`report.txt` announced as `application/pdf`) passes. An extension→mimetype
+MAPPING is deliberately not enforced, because user agents genuinely disagree about office and audio
+types (macOS reports `.csv` as `text/plain`) and a mapping would reject legitimate uploads.
+
+The legacy `fileTypeRegex` option still works and keeps precedence, but is **deprecated**: one
+expression is `.test()`ed against both the mimetype and the extension, so every alternative matches
+as a SUBSTRING — an allow-list containing `te?xt` also accepts `text/html`.
+
+Types a browser may execute as script (`text/html`, `image/svg+xml`, `application/xhtml+xml`, XML and
+JavaScript types, plus the matching extensions) are rejected **before** the allow-list is consulted,
+on both forms. A stored upload served back from the API origin with one of these content types runs
+in that origin, with the victim's session. Opt out only when the file never reaches an origin that
+carries a session:
+
+```typescript
+multerFileFilter({ extensions: ['.svg'], mimeTypes: ['image/svg+xml'] }, { allowScriptableTypes: true });
+```
+
 ---
 
 ## GraphQL Support

--- a/src/core/modules/file/core-file.controller.spec.ts
+++ b/src/core/modules/file/core-file.controller.spec.ts
@@ -1,0 +1,164 @@
+import { NotFoundException } from '@nestjs/common';
+import type { Response } from 'express';
+import { PassThrough, Readable } from 'stream';
+import { describe, expect, it } from 'vitest';
+
+import type { CoreFileService } from './core-file.service';
+import { CoreFileController, pipeFileToResponse } from './core-file.controller';
+
+/**
+ * Build a response stub that records what the handler did to it.
+ *
+ * A real `Response` is not needed here — what is under test is the decision
+ * (status vs. destroy), not Express. Writing it out as a stub also makes the
+ * "headers already sent" case reachable, which is awkward to force otherwise.
+ *
+ * What this stub CANNOT show is how Express itself treats headers: `res.json()`
+ * only defaults `Content-Type` when none is set, so a stub whose `json()` merely
+ * records a body can never reveal a stale one. That property is pinned at the
+ * HTTP level in `tests/file.e2e-spec.ts`; here we assert the removal list.
+ */
+function responseStub(headersSent = false) {
+  const sink = new PassThrough();
+  const calls = {
+    destroyed: false,
+    json: undefined as unknown,
+    removed: [] as string[],
+    set: {} as Record<string, string>,
+    status: 0,
+  };
+
+  const res = Object.assign(sink, {
+    destroy: () => {
+      calls.destroyed = true;
+      return res;
+    },
+    headersSent,
+    json: (body: unknown) => {
+      calls.json = body;
+      return res;
+    },
+    removeHeader: (name: string) => {
+      calls.removed.push(name);
+    },
+    setHeader: (name: string, value: string) => {
+      calls.set[name] = value;
+      return res;
+    },
+    status: (code: number) => {
+      calls.status = code;
+      return res;
+    },
+  }) as unknown as Response;
+
+  return { calls, res };
+}
+
+describe('pipeFileToResponse', () => {
+  it('turns a read error into 404 while nothing has been written yet', async () => {
+    // A GridFS record and its bytes are two separate writes, so the record can
+    // outlive the chunks. GridFS reports that on the stream, asynchronously.
+    // A bare `stream.pipe(res)` installs no error handler, so the error goes
+    // unhandled, Node destroys the socket mid-response, and any reverse proxy
+    // in front reports 502 Bad Gateway — "the server is down", which is the one
+    // diagnosis that is wrong while every other route answers normally.
+    const stream = new Readable({ read() {} });
+    const { calls, res } = responseStub(false);
+
+    pipeFileToResponse(stream, res);
+    stream.emit('error', new Error('FileNotFound: file 0123456789ab was not found'));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(calls.status).toBe(404);
+    expect(calls.json).toMatchObject({ statusCode: 404 });
+    expect(calls.destroyed).toBe(false);
+  });
+
+  it('drops every header that describes the file, not just the download one', async () => {
+    // Each of these would otherwise survive onto the error response:
+    // `Content-Disposition` offers a JSON error body as a file to save, a long
+    // `Cache-Control` lets the client cache the failure, `ETag` describes bytes
+    // that were never sent — and `Content-Type` makes an ofetch/`$fetch` client
+    // parse the JSON as an image and lose the message entirely.
+    const stream = new Readable({ read() {} });
+    const { calls, res } = responseStub(false);
+
+    pipeFileToResponse(stream, res);
+    stream.emit('error', new Error('chunks missing'));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(calls.removed).toEqual(
+      expect.arrayContaining(['Cache-Control', 'Content-Disposition', 'Content-Type', 'ETag']),
+    );
+    expect(calls.set['X-Content-Type-Options']).toBe('nosniff');
+  });
+
+  it('closes the connection once bytes are already on the wire', async () => {
+    // Past the first byte there is no status left to send. Dropping the
+    // connection is the only remaining signal — and it is the correct one: it
+    // is what a truncated transfer looks like, so the client does not cache a
+    // half file as if it were complete.
+    const stream = new Readable({ read() {} });
+    const { calls, res } = responseStub(true);
+
+    pipeFileToResponse(stream, res);
+    stream.emit('error', new Error('connection lost mid-stream'));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(calls.destroyed).toBe(true);
+    expect(calls.status).toBe(0);
+  });
+
+  it('answers a refused download exactly like an unknown id', async () => {
+    // `getFileStream()` returns null when the service's own `checkRights()`
+    // refuses — a branch only a CONSUMER project can reach, since the framework's
+    // base implementation always returns true. That is precisely why the
+    // framework has to pin it: consumers cannot, and if the two answers ever
+    // diverge (403 here, 404 there, or different messages) the endpoint becomes
+    // an existence oracle for files the caller may not read.
+    // Invoked through the prototype rather than a subclass: `CoreFileController`
+    // has a protected constructor (it is abstract by design), and a subclass added
+    // only to widen that visibility is exactly what `no-useless-constructor`
+    // strips — leaving code that no longer compiles.
+    const download = (service: Partial<CoreFileService>, res: Response) =>
+      (CoreFileController.prototype.getFileById as (this: unknown, id: string, res: Response) => Promise<unknown>).call(
+        { fileService: service },
+        'abc',
+        res,
+      );
+
+    const file = { contentType: 'image/png', filename: 'secret.png', id: 'abc' };
+    const { res } = responseStub(false);
+
+    const refusedErr = await download(
+      { getFileInfo: async () => file, getFileStream: async () => null } as unknown as Partial<CoreFileService>,
+      res,
+    ).catch((e: unknown) => e);
+    const unknownErr = await download(
+      { getFileInfo: async () => null, getFileStream: async () => null } as unknown as Partial<CoreFileService>,
+      res,
+    ).catch((e: unknown) => e);
+
+    expect(refusedErr).toBeInstanceOf(NotFoundException);
+    expect(unknownErr).toBeInstanceOf(NotFoundException);
+    // Byte-identical answers: same status, same message.
+    expect((refusedErr as NotFoundException).getStatus()).toBe((unknownErr as NotFoundException).getStatus());
+    expect((refusedErr as NotFoundException).getResponse()).toEqual((unknownErr as NotFoundException).getResponse());
+  });
+
+  it('destroys the source stream when the client goes away', async () => {
+    // `pipe()` only ever unpipes the DESTINATION; it never destroys the source.
+    // On a public download route an aborted request would therefore leak the
+    // GridFS read stream and its server-side cursor until the cursor timeout.
+    const stream = new Readable({ read() {} });
+    const { res } = responseStub(false);
+
+    pipeFileToResponse(stream, res);
+    expect(stream.destroyed).toBe(false);
+
+    res.emit('close');
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(stream.destroyed).toBe(true);
+  });
+});

--- a/src/core/modules/file/core-file.controller.ts
+++ b/src/core/modules/file/core-file.controller.ts
@@ -1,9 +1,81 @@
-import { BadRequestException, Controller, Get, NotFoundException, Param, Res } from '@nestjs/common';
-import { Response } from 'express';
+import { BadRequestException, Controller, Get, Logger, NotFoundException, Param, Res } from '@nestjs/common';
+import type { Response } from 'express';
+import type { Readable } from 'stream';
 
 import { Roles } from '../../common/decorators/roles.decorator';
 import { RoleEnum } from '../../common/enums/role.enum';
+import { ErrorCode } from '../error-code/error-codes';
 import { CoreFileService } from './core-file.service';
+
+const fileStreamLogger = new Logger('CoreFileController');
+
+/**
+ * Headers that describe the FILE and must not survive onto an error response.
+ *
+ * Deliberately not the whole set: CORS headers are already on the response at
+ * this point, and removing those would turn a readable 404 into an opaque CORS
+ * failure in the browser — hiding the very answer this handler exists to give.
+ *
+ * `Content-Type` is the one most easily missed. Express only defaults it in
+ * `res.json()` when nothing is set yet (`if (!this.get('Content-Type'))`), so the
+ * file's own type would otherwise label a JSON body as `image/png` — and an
+ * ofetch/`$fetch` client picks its parser from that header and hands the caller a
+ * Blob instead of the error message.
+ */
+const FILE_DELIVERY_HEADERS = ['Cache-Control', 'Content-Disposition', 'Content-Type', 'ETag'];
+
+/**
+ * Pipe a GridFS download to the response without letting a read error kill the socket.
+ *
+ * A GridFS record and its chunks are two separate writes, so a file document can
+ * outlive its bytes — an interrupted upload, a restored backup, a manual cleanup.
+ * GridFS reports that asynchronously, on the stream, and `stream.pipe(res)` alone
+ * installs no error handler: the error goes unhandled, Node destroys the socket
+ * mid-response, and any reverse proxy in front turns that into **502 Bad Gateway**.
+ * That reads as "the server is down" — the one diagnosis that is wrong here, while
+ * every other route keeps answering normally.
+ *
+ * Nothing has been written when GridFS reports a missing file, so the status is
+ * still ours to set and the answer becomes an honest 404. Once bytes are on the
+ * wire there is no status left to send and closing the connection is all that
+ * remains — but at that point it genuinely is a truncated transfer, which is
+ * exactly what a dropped connection means to the client.
+ *
+ * Note on `pipe()` vs `stream.pipeline()`: pipeline would destroy BOTH streams on
+ * error, including the response — which is precisely the object still needed to
+ * send the 404. So the source is cleaned up explicitly on `res` close instead;
+ * `pipe()` only ever unpipes the destination and would otherwise leave the
+ * GridFS read stream and its server-side cursor open on every aborted download.
+ */
+export function pipeFileToResponse(stream: Readable, res: Response): Response {
+  res.on('close', () => {
+    if (!stream.destroyed) {
+      stream.destroy();
+    }
+  });
+
+  stream.on('error', (err: Error) => {
+    // The answer to the CLIENT stays deliberately indistinguishable from an
+    // unknown id, but the server must not lose the event: a files document
+    // without its chunks is data corruption, and an error silently converted
+    // into a 404 is one nobody will ever notice.
+    fileStreamLogger.error(`GridFS download failed: ${err.message}`, err.stack);
+
+    if (res.headersSent) {
+      res.destroy();
+      return;
+    }
+    for (const header of FILE_DELIVERY_HEADERS) {
+      res.removeHeader(header);
+    }
+    // No global nosniff on this route, and the body is now correctly typed —
+    // set it anyway so a mislabelled response can never be sniffed into markup.
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.status(404).json({ error: 'Not Found', message: ErrorCode.FILE_NOT_FOUND, statusCode: 404 });
+  });
+
+  return stream.pipe(res);
+}
 
 /**
  * File controller
@@ -17,6 +89,18 @@ export abstract class CoreFileController {
   protected constructor(protected fileService: CoreFileService) {}
 
   /**
+   * Stream a file to the response.
+   *
+   * Delegates to the module-level {@link pipeFileToResponse} (which stays exported
+   * so it can be unit-tested without a Nest context). Override this to change the
+   * error status, the body shape or the logging for a project — the free function
+   * alone would not be reachable from a subclass.
+   */
+  protected pipeFileToResponse(stream: Readable, res: Response): Response {
+    return pipeFileToResponse(stream, res);
+  }
+
+  /**
    * Download file by ID
    *
    * More reliable than filename-based download as IDs are unique.
@@ -26,17 +110,22 @@ export abstract class CoreFileController {
   @Roles(RoleEnum.S_EVERYONE)
   async getFileById(@Param('id') id: string, @Res() res: Response) {
     if (!id) {
-      throw new BadRequestException('Missing file ID for download');
+      throw new BadRequestException(ErrorCode.REQUIRED_FIELD_MISSING);
     }
 
     const file = await this.fileService.getFileInfo(id);
     if (!file) {
-      throw new NotFoundException('File not found');
+      throw new NotFoundException(ErrorCode.FILE_NOT_FOUND);
     }
     const filestream = await this.fileService.getFileStream(id);
+    // `getFileStream` answers null when the service's own rights check refuses.
+    // Same answer as an unknown id: never confirm that the file exists.
+    if (!filestream) {
+      throw new NotFoundException(ErrorCode.FILE_NOT_FOUND);
+    }
     res.header('Content-Type', file.contentType || 'application/octet-stream');
     res.header('Content-Disposition', `attachment; filename=${file.filename}`);
-    return filestream.pipe(res);
+    return this.pipeFileToResponse(filestream, res);
   }
 
   /**
@@ -49,16 +138,19 @@ export abstract class CoreFileController {
   @Roles(RoleEnum.S_EVERYONE)
   async getFile(@Param('filename') filename: string, @Res() res: Response) {
     if (!filename) {
-      throw new BadRequestException('Missing filename for download');
+      throw new BadRequestException(ErrorCode.REQUIRED_FIELD_MISSING);
     }
 
     const file = await this.fileService.getFileInfoByName(filename);
     if (!file) {
-      throw new NotFoundException('File not found');
+      throw new NotFoundException(ErrorCode.FILE_NOT_FOUND);
     }
     const filestream = await this.fileService.getFileStream(file.id);
+    if (!filestream) {
+      throw new NotFoundException(ErrorCode.FILE_NOT_FOUND);
+    }
     res.header('Content-Type', file.contentType || 'application/octet-stream');
     res.header('Content-Disposition', `attachment; filename=${file.filename}`);
-    return filestream.pipe(res);
+    return this.pipeFileToResponse(filestream, res);
   }
 }

--- a/src/core/modules/migrate/README.md
+++ b/src/core/modules/migrate/README.md
@@ -387,6 +387,41 @@ const fileId = await uploadFileToGridFS('mongodb://localhost/mydb', '../assets/i
 });
 ```
 
+`relativePath` is resolved against the **helper module's** directory, not the migration file's — the
+paths in this example and in the migration template are written accordingly.
+
+The returned promise settles only after three guarantees hold:
+
+| Guarantee                       | Behaviour                                                                                                                                                                                                         |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| The bytes are stored            | Chunk completeness is verified before resolving (see `assertGridFsFileComplete()` below). An incomplete upload **rejects** and the incomplete file is removed, rather than returning an id that points at nothing |
+| An unreadable source fails fast | A missing or unreadable file **rejects** with the underlying `ENOENT`. It used to hang forever, because `pipe()` does not forward read-stream errors                                                              |
+| The connection is released      | The MongoClient it opens is always closed, on the success and the failure path alike. A leaked connection keeps the Node event loop alive and `migrate up` never exits                                            |
+
+Since these are hard failures, a seed migration whose asset is missing or only partially stored now
+fails the migration — and with the default `MIGRATE_FAILURE_POLICY=abort` in `docker-entrypoint.sh`,
+the container refuses to start rather than booting with broken data. That is intentional: the point
+of running migrations before the server is to find exactly this.
+
+### assertGridFsFileComplete()
+
+Verifies that every chunk of an already-stored GridFS file is present. `uploadFileToGridFS()` calls
+it for you; call it directly to check files written by something else (a restored dump, another
+service, a manual upload):
+
+```typescript
+import { assertGridFsFileComplete, getDb } from '@lenne.tech/nest-server';
+
+const db = await getDb('mongodb://localhost/mydb');
+await assertGridFsFileComplete(db, 'images', fileId, 'logo.png'); // throws if incomplete
+```
+
+Throws when the files document is missing entirely, or when fewer chunks are stored than its
+`length` implies. It counts chunk documents rather than reading bytes back, so a chunk that was
+written but truncated is **not** detected — the check targets the failure that actually occurs, a
+connection lost mid-upload. Empty files are valid and pass: GridFS stores a zero-byte file with no
+chunk documents at all.
+
 ### Migration Templates
 
 Ready-to-use template for nest-server projects:

--- a/src/core/modules/migrate/cli/migrate-cli.ts
+++ b/src/core/modules/migrate/cli/migrate-cli.ts
@@ -328,13 +328,76 @@ Environment Variables:
 `);
 }
 
-// Run CLI if executed directly
-if (require.main === module) {
-  main().catch((error) => {
+/**
+ * Exit with `code`, but never before our own output has actually left the process.
+ *
+ * `process.exit()` does NOT drain stdout, and stdout is asynchronous whenever it
+ * is a pipe — which is exactly the Docker / CI / `| tee` case. Exiting straight
+ * after the completion log therefore discards the record of what this run did,
+ * and the line at risk is the last one ("All migrations completed successfully"),
+ * which is precisely what a CI step greps for. Measured: past the 64 KiB pipe
+ * buffer everything beyond it is lost.
+ *
+ * `process.exitCode` is assigned first so that a future `exitCode = 1` elsewhere
+ * is honoured rather than overwritten by a hardcoded 0. The timer is the safety
+ * net for the opposite failure — a consumer that never reads — and is `unref`'d
+ * so it cannot itself keep the process alive.
+ */
+const flushAndExit = async (code: number): Promise<void> => {
+  process.exitCode = code;
+
+  const guard = setTimeout(() => process.exit(code), 5000);
+  guard.unref();
+
+  await Promise.all(
+    [process.stdout, process.stderr].map(
+      (stream) =>
+        new Promise<void>((resolve) => {
+          if (!stream.writableLength) {
+            resolve();
+            return;
+          }
+          stream.write('', () => resolve());
+        }),
+    ),
+  );
+
+  clearTimeout(guard);
+  process.exit(code);
+};
+
+/**
+ * Run the CLI and terminate the process when it is done.
+ *
+ * This is the entry point the `migrate` / `nest-migrate` bin uses. It exists
+ * separately from `main()` because the shell around it matters: migrations touch
+ * MongoDB, GridFS and — via the state store — a second connection, and any handle
+ * one of them leaves behind keeps Node alive forever. The CLI then prints
+ * "All migrations completed successfully" and simply never returns: a CI job
+ * blocks until its timeout, and a container entrypoint that runs migrations
+ * before `exec`ing the server never reaches the server at all.
+ *
+ * Note this must NOT be guarded by `require.main === module`: the shipped
+ * `bin/migrate.js` loads this module and calls in, so `require.main` is the shim,
+ * never this file. A guard here would make the exit unreachable on every path
+ * that actually ships.
+ */
+const runCli = async (): Promise<void> => {
+  try {
+    await main();
+  } catch (error) {
     console.error('Fatal error:', error);
-    process.exit(1);
-  });
+    await flushAndExit(1);
+    return;
+  }
+  await flushAndExit(0);
+};
+
+// Run CLI if executed directly (`node migrate-cli.js`). The bin shim calls
+// runCli() itself, so this only covers a direct invocation of the compiled file.
+if (require.main === module) {
+  void runCli();
 }
 
 // parseArgs is exported for unit testing only (same pattern as resolveCliPath in bin/migrate.js)
-export { main, parseArgs };
+export { flushAndExit, main, parseArgs, runCli };

--- a/src/core/modules/migrate/helpers/migration.helper.spec.ts
+++ b/src/core/modules/migrate/helpers/migration.helper.spec.ts
@@ -1,0 +1,85 @@
+import type { Db } from 'mongodb';
+import { ObjectId } from 'mongodb';
+import { describe, expect, it } from 'vitest';
+
+import { assertGridFsFileComplete } from './migration.helper';
+
+/**
+ * Minimal stand-in for the two collections the check reads.
+ *
+ * A real Mongo instance is not needed to pin this contract — what matters is
+ * the decision the function makes given a files document and a chunk count.
+ * The stub records what it was asked for, so a hardcoded bucket name or a wrong
+ * filter key cannot slip past unnoticed; the real-MongoDB counterpart lives in
+ * `tests/migrate/upload-file-to-gridfs.e2e-spec.ts`.
+ */
+function dbStub(files: null | Record<string, unknown>, chunkCount: number) {
+  const asked: { filters: unknown[]; names: string[] } = { filters: [], names: [] };
+
+  const db = {
+    collection: (name: string) => {
+      asked.names.push(name);
+      if (name.endsWith('.files')) {
+        return {
+          findOne: async (filter: unknown) => {
+            asked.filters.push(filter);
+            return files;
+          },
+        };
+      }
+      return {
+        countDocuments: async (filter: unknown) => {
+          asked.filters.push(filter);
+          return chunkCount;
+        },
+      };
+    },
+  } as unknown as Db;
+
+  return { asked, db };
+}
+
+describe('assertGridFsFileComplete', () => {
+  const id = new ObjectId();
+
+  it('passes when every chunk is stored', async () => {
+    // 700 KiB at the default 255 KiB chunk size = 3 chunks.
+    const { db } = dbStub({ _id: id, chunkSize: 261120, length: 716800 }, 3);
+    await expect(assertGridFsFileComplete(db, 'fs', id, 'layout.jpg')).resolves.toBeUndefined();
+  });
+
+  it('rejects when the record promises more bytes than exist', async () => {
+    // The nasty case: the files document looks perfectly healthy, so every
+    // listing and every metadata check says the file is fine — only the
+    // download fails. Reporting this at upload time is what keeps a broken
+    // asset from being persisted as if it were good.
+    const { db } = dbStub({ _id: id, chunkSize: 261120, length: 716800 }, 1);
+    await expect(assertGridFsFileComplete(db, 'fs', id, 'layout.jpg')).rejects.toThrow(/incomplete: 1 of 3 chunks/);
+  });
+
+  it('rejects when the file document is missing entirely', async () => {
+    const { db } = dbStub(null, 0);
+    await expect(assertGridFsFileComplete(db, 'fs', id, 'layout.jpg')).rejects.toThrow(/no file document/);
+  });
+
+  it('accepts an empty file, which GridFS stores with no chunks at all', async () => {
+    // GridFS does NOT write a placeholder chunk for a zero-byte file: the
+    // driver's `writeRemnant()` returns early on `pos === 0`. A `Math.max(1, …)`
+    // floor in the expectation would therefore reject every legitimately empty
+    // asset — and since the container entrypoint defaults to
+    // `MIGRATE_FAILURE_POLICY=abort`, that would keep the server from starting.
+    const { db } = dbStub({ _id: id, chunkSize: 261120, length: 0 }, 0);
+    await expect(assertGridFsFileComplete(db, 'fs', id, 'empty.bin')).resolves.toBeUndefined();
+  });
+
+  it('reads the bucket it was given, filtered by the file id', async () => {
+    // Guards the two things the assertions above cannot see: that the bucket
+    // name is not hardcoded, and that the chunk lookup uses `files_id` (a wrong
+    // key would count zero and turn every upload into a false failure).
+    const { asked, db } = dbStub({ _id: id, chunkSize: 261120, length: 261120 }, 1);
+    await assertGridFsFileComplete(db, 'images', id, 'logo.png');
+
+    expect(asked.names).toEqual(['images.files', 'images.chunks']);
+    expect(asked.filters).toEqual([{ _id: id }, { files_id: id }]);
+  });
+});

--- a/src/core/modules/migrate/helpers/migration.helper.ts
+++ b/src/core/modules/migrate/helpers/migration.helper.ts
@@ -68,12 +68,75 @@ export const getDb = async (mongoUrl: string): Promise<Db> => {
 };
 
 /**
+ * Throw unless every chunk of a stored GridFS file is present.
+ *
+ * A GridFS upload is not one write but many: N chunk documents plus the files
+ * document that describes them. The write stream's `'finish'` event says the
+ * stream ended — it does not prove every chunk is durably there, and a
+ * connection that goes away at the wrong moment can leave a files document
+ * behind that promises more bytes than exist. The upload then "succeeds", the
+ * caller stores the id, and the defect only surfaces much later as a broken
+ * download from a record that looks perfectly healthy.
+ *
+ * Counts documents rather than reading bytes, so a chunk that was written but
+ * truncated still passes. Catching that would mean streaming the whole file
+ * back on every upload; the cheap count catches the failure that actually
+ * occurs (a missing chunk) and is index-only via the GridFS default index.
+ *
+ * @param db - Database holding the bucket
+ * @param bucketName - GridFS bucket name, i.e. the prefix of `<bucket>.files` / `<bucket>.chunks`
+ * @param id - `_id` of the files document
+ * @param label - Optional human-readable name for the error message; defaults to the id
+ * @throws Error if the files document is missing or fewer chunks are stored than its length implies
+ *
+ * @example
+ * ```typescript
+ * await assertGridFsFileComplete(db, 'images', fileId, 'logo.png');
+ * ```
+ */
+export const assertGridFsFileComplete = async (
+  db: Db,
+  bucketName: string,
+  id: ObjectId,
+  label?: string,
+): Promise<void> => {
+  const name = label || String(id);
+  const fileDoc = await db.collection(`${bucketName}.files`).findOne({ _id: id });
+  if (!fileDoc) {
+    throw new Error(`GridFS file '${name}' has no file document (id ${String(id)})`);
+  }
+
+  const chunkSize: number = fileDoc.chunkSize || 255 * 1024;
+  // NO `Math.max(1, …)` floor here: GridFS stores ZERO chunk documents for a
+  // zero-byte file — the driver's `writeRemnant()` returns early on `pos === 0`
+  // rather than inserting an empty chunk. A floor of 1 would reject every
+  // legitimately empty asset, and because the container entrypoint defaults to
+  // `MIGRATE_FAILURE_POLICY=abort`, that failure would keep the server from
+  // starting at all.
+  const expected = Math.ceil((fileDoc.length || 0) / chunkSize);
+  const actual = await db
+    .collection(`${bucketName}.chunks`)
+    // Read from the primary: this is a read-your-own-write, and a URI carrying
+    // `readPreference=secondaryPreferred` would otherwise fail a healthy upload
+    // against a secondary that has not caught up yet.
+    .countDocuments({ files_id: id }, { readPreference: 'primary' });
+  if (actual < expected) {
+    throw new Error(`GridFS file '${name}' is incomplete: ${actual} of ${expected} chunks stored (id ${String(id)})`);
+  }
+};
+
+/**
  * Upload file to GridFS
  *
+ * Resolves only once the upload is verified complete (see
+ * {@link assertGridFsFileComplete}); rejects — rather than hanging — when the
+ * source file cannot be read. Closes its own connection either way.
+ *
  * @param mongoUrl - MongoDB connection URI
- * @param relativePath - Relative path to the file
+ * @param relativePath - Path to the file, resolved against this module's directory
  * @param options - Optional bucket name and filename
  * @returns Promise with ObjectId of uploaded file
+ * @throws Error if the source cannot be read, or if the stored file is incomplete
  *
  * @example
  * ```typescript
@@ -100,19 +163,83 @@ export const uploadFileToGridFS = async (
   };
 
   const client = await MongoClient.connect(mongoUrl);
+  // Registered unconditionally — unlike `getDb()`, which only registers inside a
+  // migration context. This client is always ours to close, so `_endMigration()`
+  // stays a backstop for the case where the upload throws before `settle()` runs.
+  activeConnections.add(client);
+
   const db = client.db();
   const bucket = new GridFSBucket(db, { bucketName });
   const writeStream = bucket.openUploadStream(filename);
 
-  const rs = fs.createReadStream(path.resolve(__dirname, relativePath)).pipe(writeStream);
+  const readStream = fs.createReadStream(path.resolve(__dirname, relativePath));
+  const rs = readStream.pipe(writeStream);
+
+  /**
+   * Read errors need their own handler — `pipe()` does not forward them.
+   *
+   * An unreadable source (missing file, wrong path inside a container image)
+   * emits on the READ stream, where nothing was listening: the write stream
+   * never finished, the promise below never settled, and the migration hung
+   * until something else timed out. Destroying the write stream routes it into
+   * the rejection path so the caller sees the actual cause.
+   */
+  readStream.on('error', (err) => {
+    writeStream.destroy(err);
+  });
+
+  /**
+   * Close the connection before settling.
+   *
+   * This client used to be opened and never closed, and it was not registered
+   * either — so `_endMigration()` could not reach it. Every uploaded file left a
+   * live connection behind, and a live connection keeps an SDAM monitor timer
+   * alive, which keeps the Node event loop busy: `migrate up` finished its work,
+   * printed "All migrations completed successfully" and then never exited. That
+   * is invisible on a developer machine and blocks a CI job until its timeout.
+   *
+   * A failing `close()` must never become the error the caller sees: the reason
+   * the upload ended is what matters, and the settle path is also reached while
+   * rejecting. So the close error is logged and swallowed, and `settled` keeps a
+   * second call (success path falling into `.catch`) from closing twice.
+   */
+  let settled = false;
+  const settle = async <T>(action: () => T): Promise<T> => {
+    if (!settled) {
+      settled = true;
+      try {
+        await client.close();
+      } catch (closeErr) {
+        console.warn('Failed to close migration connection:', closeErr);
+      } finally {
+        activeConnections.delete(client);
+      }
+    }
+    return action();
+  };
 
   return new Promise<ObjectId>((resolve, reject) => {
     rs.on('finish', () => {
-      resolve(writeStream.id as ObjectId);
+      const id = writeStream.id as ObjectId;
+      // Verify BEFORE closing: the check needs the same open client, and a
+      // failure has to reject rather than hand back an id that points at nothing.
+      assertGridFsFileComplete(db, bucketName, id, filename)
+        .then(() => settle(() => id))
+        .then(resolve)
+        .catch((err: unknown) => {
+          // Drop the incomplete file, otherwise every re-run of the migration
+          // leaves another orphaned files document (plus its partial chunks)
+          // behind, since a retry uploads under a fresh ObjectId.
+          bucket
+            .delete(id)
+            .catch(() => undefined)
+            .then(() => settle(() => undefined))
+            .finally(() => reject(err));
+        });
     });
 
     rs.on('error', (err) => {
-      reject(err);
+      settle(() => undefined).finally(() => reject(err));
     });
   });
 };

--- a/tests/migrate/upload-file-to-gridfs.e2e-spec.ts
+++ b/tests/migrate/upload-file-to-gridfs.e2e-spec.ts
@@ -1,0 +1,168 @@
+/**
+ * E2E tests for `uploadFileToGridFS`.
+ *
+ * The helper is used by seed migrations to put binary assets (images, PDFs)
+ * into GridFS before the server boots. Three of its guarantees are load-bearing
+ * and were all missing once:
+ *
+ * 1. **The bytes are really there when it resolves.** A GridFS upload is N
+ *    chunk documents plus one files document. `'finish'` only says the stream
+ *    ended. A helper that trusts it can hand back an id that points at an
+ *    incomplete file — the caller stores that id, and the defect surfaces much
+ *    later as a broken download from a record that looks healthy.
+ * 2. **An unreadable source rejects instead of hanging.** `pipe()` does not
+ *    forward read-stream errors, so a missing file used to leave the promise
+ *    pending forever — a migration that never returns and a container that
+ *    never reaches its server.
+ * 3. **The connection is closed when it settles.** A leaked client keeps an
+ *    SDAM monitor timer alive, which keeps the Node event loop busy: `migrate up`
+ *    prints "All migrations completed successfully" and never exits.
+ *
+ * Guarantee 3 is the one a stub can never show, which is why it is asserted here
+ * against a real MongoDB rather than in the unit spec.
+ */
+
+import { randomBytes } from 'crypto';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { GridFSBucket, MongoClient } from 'mongodb';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { uploadFileToGridFS } from '../../src/core/modules/migrate/helpers/migration.helper';
+import { deriveTestDbUri } from '../db-lifecycle.reporter';
+
+describe('uploadFileToGridFS (e2e)', () => {
+  // Always derive from the per-run database. An env escape hatch here would only
+  // ever be able to point the suite at a NON-test database — nothing in the repo
+  // sets one, and `global-setup.ts` guards its own override with a safe-name
+  // pattern that this file could not reuse.
+  const mongoUrl = deriveTestDbUri('gridfs-upload');
+  const bucketName = 'uploadhelper';
+
+  let client: MongoClient | undefined;
+  let workDir: string | undefined;
+
+  beforeAll(async () => {
+    client = await MongoClient.connect(mongoUrl);
+    workDir = mkdtempSync(join(tmpdir(), 'gridfs-upload-'));
+  });
+
+  afterAll(async () => {
+    // Null-guarded: if beforeAll failed (no mongod), an unguarded teardown throws
+    // a TypeError that masks the real cause.
+    if (client) {
+      for (const name of [`${bucketName}.files`, `${bucketName}.chunks`]) {
+        await client
+          .db()
+          .collection(name)
+          .drop()
+          .catch(() => undefined);
+      }
+      await client.close();
+    }
+    if (workDir) {
+      rmSync(workDir, { force: true, recursive: true });
+    }
+  });
+
+  it('stores every chunk of a multi-chunk file', async () => {
+    // Deliberately larger than one 255 KiB chunk: a single-chunk file would
+    // pass even if only the first chunk were ever written, which is precisely
+    // the failure this helper has to rule out.
+    const source = join(workDir!, 'multi-chunk.bin');
+    const payload = randomBytes(700 * 1024);
+    writeFileSync(source, payload);
+
+    const id = await uploadFileToGridFS(mongoUrl, source, { bucketName });
+
+    const files = await client!.db().collection(`${bucketName}.files`).findOne({ _id: id });
+    expect(files).toBeTruthy();
+    expect(files!.length).toEqual(payload.length);
+
+    const chunks = await client!.db().collection(`${bucketName}.chunks`).countDocuments({ files_id: id });
+    expect(chunks).toEqual(Math.ceil(payload.length / files!.chunkSize));
+
+    // And the bytes read back identical — the count alone would not catch a
+    // chunk that was written but truncated.
+    const downloaded: Buffer[] = [];
+    const bucket = new GridFSBucket(client!.db(), { bucketName });
+    await new Promise<void>((resolve, reject) => {
+      bucket
+        .openDownloadStream(id)
+        .on('data', (chunk: Buffer) => downloaded.push(chunk))
+        .on('end', resolve)
+        .on('error', reject);
+    });
+    expect(Buffer.concat(downloaded).equals(payload)).toBe(true);
+  });
+
+  it('accepts an empty file, which GridFS stores with no chunks at all', async () => {
+    // The driver skips the insert entirely for a zero-length buffer
+    // (`writeRemnant()` returns early on `pos === 0`), so the completeness check
+    // must not demand a minimum of one chunk. It did once — and because the
+    // container entrypoint defaults to `MIGRATE_FAILURE_POLICY=abort`, a seed
+    // migration carrying an empty placeholder would have blocked the boot.
+    const source = join(workDir!, 'empty.bin');
+    writeFileSync(source, Buffer.alloc(0));
+
+    const id = await uploadFileToGridFS(mongoUrl, source, { bucketName });
+
+    const files = await client!.db().collection(`${bucketName}.files`).findOne({ _id: id });
+    expect(files!.length).toEqual(0);
+    await expect(client!.db().collection(`${bucketName}.chunks`).countDocuments({ files_id: id })).resolves.toEqual(0);
+  });
+
+  it('resolves a relative path against the helper module, as every documented caller does', async () => {
+    // The README, the migration template and the 11.3.x guide all pass a
+    // RELATIVE path, which `path.resolve(__dirname, …)` anchors at the helper's
+    // own directory. An absolute path silently bypasses that anchoring (resolve
+    // discards the base), so only this case exercises the real code path.
+    const id = await uploadFileToGridFS(mongoUrl, '../templates/migration-project.template.ts', { bucketName });
+
+    const files = await client!.db().collection(`${bucketName}.files`).findOne({ _id: id });
+    expect(files).toBeTruthy();
+    expect(files!.filename).toEqual('migration-project.template.ts');
+    expect(files!.length).toBeGreaterThan(0);
+  });
+
+  it('rejects a source file that cannot be read instead of hanging', async () => {
+    // `pipe()` does not forward read-stream errors. Without an explicit handler
+    // the write stream never finishes and the promise never settles — the
+    // migration simply stops, with no error to point at.
+    //
+    // Matched on ENOENT rather than a bare `toThrow()`: an unmatched assertion
+    // would also pass on a connection failure, i.e. for a reason that has
+    // nothing to do with the handler under test.
+    await expect(uploadFileToGridFS(mongoUrl, join(workDir!, 'does-not-exist.bin'), { bucketName })).rejects.toThrow(
+      /ENOENT/,
+    );
+  });
+
+  it('closes its connection on both the success and the failure path', async () => {
+    // The headline fix: an unclosed client keeps an SDAM monitor timer alive and
+    // the CLI never exits. Asserted by handle count rather than by inspecting the
+    // private client — N uploads must not leave N connections behind, which is
+    // exactly what the leak looked like.
+    const source = join(workDir!, 'handles.bin');
+    writeFileSync(source, randomBytes(1024));
+
+    // Warm up first: the very first connect lazily creates driver-internal
+    // resources that would otherwise be counted as growth.
+    await uploadFileToGridFS(mongoUrl, source, { bucketName });
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    const before = process.getActiveResourcesInfo().length;
+
+    for (let i = 0; i < 3; i++) {
+      await uploadFileToGridFS(mongoUrl, source, { bucketName });
+    }
+    // And a failing upload, which settles through the reject path.
+    await expect(uploadFileToGridFS(mongoUrl, join(workDir!, 'nope.bin'), { bucketName })).rejects.toThrow();
+
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    const after = process.getActiveResourcesInfo().length;
+
+    // Four more connections would show up plainly; allow a small margin for
+    // unrelated timers rather than demanding an exact match.
+    expect(after - before).toBeLessThan(4);
+  });
+});

--- a/tests/unit/audit-suppression-scope.spec.ts
+++ b/tests/unit/audit-suppression-scope.spec.ts
@@ -1,0 +1,62 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Guards the assumption that makes an audit suppression defensible.
+ *
+ * `auditConfig.ignoreGhsas` in `pnpm-workspace.yaml` takes a bare GHSA id — pnpm
+ * offers no path, package or dev/prod scoping. So an entry added for a dev-only
+ * finding silently keeps suppressing that advisory if it later appears on a
+ * PRODUCTION path, and `pnpm audit` (a blocking gate in `.github/workflows/build.yml`)
+ * would stay green. The written justification is the only thing holding it, and a
+ * comment cannot fail a build.
+ *
+ * This spec turns that justification into an assertion: the moment a suppressed
+ * advisory's package reaches the production tree, the build fails and the entry
+ * has to be re-argued or removed.
+ *
+ * Reads the lockfile via `pnpm why` — no network, no install.
+ */
+
+const ROOT = join(__dirname, '../..');
+
+/** Packages whose advisories are currently suppressed, and must stay dev-only. */
+const DEV_ONLY_SUPPRESSIONS = [
+  {
+    // GHSA-mh99-v99m-4gvg — unbounded expansion (OOM). Patched only in 5.0.8;
+    // 1.1.16 has no length guard. The remaining path is
+    // @nestjs/cli > fork-ts-checker-webpack-plugin > minimatch@3 > brace-expansion@1,
+    // which cannot be lifted (minimatch@10 has no callable default export).
+    ghsa: 'GHSA-mh99-v99m-4gvg',
+    pkg: 'brace-expansion',
+    vulnerableInProd: /^brace-expansion@[12]\./m,
+  },
+];
+
+describe('audit suppressions stay within their justification', () => {
+  const workspace = readFileSync(join(ROOT, 'pnpm-workspace.yaml'), 'utf8');
+
+  it('suppresses only the advisories this spec knows about', () => {
+    // A new entry must come with a matching guard here, or it is unguarded by
+    // definition — which is the failure mode this file exists to prevent.
+    const listed = Array.from(workspace.matchAll(/^\s*-\s*(GHSA-[\w-]+)\s*$/gm)).map((m) => m[1]);
+    expect(listed.sort()).toEqual(DEV_ONLY_SUPPRESSIONS.map((s) => s.ghsa).sort());
+  });
+
+  for (const { ghsa, pkg, vulnerableInProd } of DEV_ONLY_SUPPRESSIONS) {
+    it(`keeps ${pkg} (${ghsa}) out of the production dependency tree`, () => {
+      // `--prod` walks `dependencies` only. If the vulnerable major shows up
+      // here, the "dev tooling only, no consumer and no runtime reaches it"
+      // argument behind the suppression no longer holds.
+      const out = execFileSync('pnpm', ['why', pkg, '--prod'], {
+        cwd: ROOT,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      expect(out).not.toMatch(vulnerableInProd);
+    }, 60_000);
+  }
+});

--- a/tests/unit/fixtures/migrate-cli-exit-child.ts
+++ b/tests/unit/fixtures/migrate-cli-exit-child.ts
@@ -1,0 +1,32 @@
+/**
+ * Fixture for `migrate-cli-exit.spec.ts`.
+ *
+ * Reproduces both halves of the situation the CLI's exit path exists for:
+ *
+ * 1. A leaked handle. `setInterval` without `unref()` stands in for the MongoDB /
+ *    GridFS / state-store connections a migration leaves behind — without an
+ *    explicit exit the process would run forever here.
+ * 2. More buffered output than a pipe can hold. `process.exit()` does not drain
+ *    stdout, so a naive exit truncates everything past the ~64 KiB pipe buffer,
+ *    including the last line — which is what CI greps for.
+ *
+ * Prints a sentinel as the very last line so the test can assert nothing was cut.
+ *
+ * Writes via `process.stdout.write` rather than `console.log` ON PURPOSE: the
+ * repo's lint auto-fix strips `console.*` calls here, which would silently empty
+ * this fixture and leave a test that passes against no output at all. The direct
+ * write is also exactly what the CLI's own drain operates on.
+ */
+
+import { flushAndExit } from '../../../src/core/modules/migrate/cli/migrate-cli';
+
+// The leak. Deliberately NOT unref'd.
+setInterval(() => undefined, 1000);
+
+const lines = Number(process.env.FIXTURE_LINES || 20000);
+for (let i = 0; i < lines; i++) {
+  process.stdout.write(`line-${i}-padding-padding-padding-padding-padding-padding\n`);
+}
+process.stdout.write('SENTINEL-LAST-LINE\n');
+
+void flushAndExit(0);

--- a/tests/unit/migrate-cli-exit.spec.ts
+++ b/tests/unit/migrate-cli-exit.spec.ts
@@ -1,0 +1,88 @@
+import { spawn } from 'node:child_process';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Proves the CLI's exit path against a REAL process, which an in-process test cannot.
+ *
+ * Two guarantees are load-bearing and neither is observable without a child:
+ *
+ * 1. **It terminates even when a handle leaks.** Migrations hold MongoDB, GridFS
+ *    and state-store connections; one left open keeps the event loop alive and
+ *    `migrate up` never returns. `docker-entrypoint.sh` runs migrations before it
+ *    `exec`s the server, so the container never reaches the server at all — and
+ *    with no timeout anywhere, it hangs rather than fails.
+ * 2. **It does not truncate its own output.** `process.exit()` does NOT drain
+ *    stdout, and stdout is asynchronous whenever it is a pipe — Docker's log
+ *    driver and every CI log collector are pipes. Past the ~64 KiB pipe buffer a
+ *    naive exit discards the rest, and the line at risk is the LAST one, which is
+ *    exactly the completion marker a CI step greps for.
+ *
+ * Costs one `tsx` child (~2 s), needs no MongoDB, and stays in the unit runner.
+ */
+
+const FIXTURE = join(process.cwd(), 'tests/unit/fixtures/migrate-cli-exit-child.ts');
+
+/**
+ * Runs the fixture and collects everything it wrote.
+ *
+ * The fixture emits ~1 MB, far past the 64 KiB kernel pipe buffer. Deliberately
+ * NO artificial pause on the read side: pausing lets the child finish and close
+ * the pipe while the stream is still parked, so the unread bytes vanish for a
+ * reason that has nothing to do with the code under test — an earlier version of
+ * this spec failed exactly that way.
+ *
+ * Scope of what this proves, measured by mutation rather than assumed:
+ * - Removing the exit entirely → this test FAILS on the 30 s timeout. The
+ *   termination guarantee is genuinely pinned here.
+ * - Replacing `flushAndExit` with a bare `process.exit(0)` → this test still
+ *   passes, because a fast local reader keeps the buffer drained. The same
+ *   mutation DOES truncate (377 KB of 1.06 MB) when run outside the vitest
+ *   worker, so the completeness assertion below is a real invariant, just not one
+ *   this environment can be relied on to break. Do not read a green run here as
+ *   proof that the drain is present.
+ */
+async function runFixture(lines: number): Promise<{ code: null | number; stderr: string; stdout: string }> {
+  const proc = spawn(process.execPath, ['--import', 'tsx', FIXTURE], {
+    cwd: process.cwd(),
+    env: { ...process.env, FIXTURE_LINES: String(lines) },
+  });
+
+  let stdout = '';
+  let stderr = '';
+  proc.stdout.on('data', (chunk: Buffer) => {
+    stdout += chunk.toString();
+  });
+  proc.stderr.on('data', (chunk: Buffer) => {
+    stderr += chunk.toString();
+  });
+  // Wait for 'close', NOT 'exit'. 'exit' fires when the process ends, which can
+  // be BEFORE the buffered stdout has been read — the assertions would then run
+  // against a half-collected string and fail for a reason that has nothing to do
+  // with the drain under test. 'close' fires once every stdio stream is done.
+  const code = await new Promise<null | number>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      proc.kill('SIGKILL');
+      reject(new Error(`CLI did not exit within 30s — the leaked handle kept it alive. stderr:\n${stderr}`));
+    }, 30_000);
+    proc.on('close', (exitCode) => {
+      clearTimeout(timer);
+      resolve(exitCode);
+    });
+    proc.on('error', reject);
+  });
+
+  return { code, stderr, stdout };
+}
+
+describe('migrate CLI exit path', () => {
+  it('exits despite a leaked handle, without losing buffered output', async () => {
+    const lines = 20000;
+    const { code, stderr, stdout } = await runFixture(lines);
+
+    expect(code, `child failed. stderr:\n${stderr}`).toBe(0);
+    // The sentinel is written last, so its presence proves nothing before it was cut.
+    expect(stdout, `stderr:\n${stderr}`).toContain('SENTINEL-LAST-LINE');
+    expect(stdout.match(/^line-\d+-padding/gm)).toHaveLength(lines);
+  }, 40_000);
+});


### PR DESCRIPTION
Release 11.32.4.

**GridFS uploads are verified before they report success.** `uploadFileToGridFS()` resolved on the write stream's `'finish'` event, which does not prove the chunk documents are stored. It now checks chunk completeness and rejects (removing its own incomplete file) instead of returning an id that points at a broken asset. An unreadable source rejects instead of hanging forever, and the MongoClient is closed on every path.

**File downloads answer honestly.** A GridFS read error mid-request went unhandled, Node destroyed the socket, and a reverse proxy reported 502 Bad Gateway. It is now a 404 with `ErrorCode.FILE_NOT_FOUND` — the same answer as an unknown id, so the endpoint cannot be used to probe which files exist. A `checkRights()` refusal that used to crash with 500 is now that same 404.

**`migrate up` terminates.** The CLI drains stdout and exits explicitly rather than waiting for the event loop to empty; a leaked handle used to keep the process alive after "All migrations completed successfully", which blocks a CI job until timeout and stops a container from ever reaching its server. The exit lives in the new exported `runCli()` — not behind `require.main === module`, which is never true through the shipped `bin/migrate.js`.

**Upload filters match whole values.** `multerFileFilter` `.test()`ed one expression against both the mimetype and the extension, i.e. a substring search: an allow-list containing `te?xt` also accepted `text/html`. The new `UploadAllowList` compares exact values, scriptable types (`text/html`, `image/svg+xml`, JS/XML) are rejected on both forms unless explicitly opted into, `fileTypeRegex: undefined` no longer silently disables all filtering, and rejections are a real `Error` instead of a bare string (which surfaced as 500 rather than 4xx). `fileTypeRegex` still works and is deprecated, not removed.

**Dependency housekeeping.** New `js-yaml` override for GHSA-pm4m-ph32-ghv5 — `@nestjs/swagger` exact-pins `js-yaml@5.2.1`, so consumers need this override too; `docs/security-overrides.md` now lists all three affected packages. The `minimatch` override was floored at `>=9.0.0` (majors 5–8 export a callable function and break under a forced lift to 10). One knowingly-unfixed advisory is recorded in `auditConfig.ignoreGhsas` with its rationale and guarded by `tests/unit/audit-suppression-scope.spec.ts`, which fails the build if the package ever reaches the production tree.

Migration guide: `migration-guides/11.32.3-to-11.32.4.md`

`pnpm run check` green locally: 2477 tests, audit 0 live findings, build + swc-tdz + server-start clean.