### PR TITLE
docs: correct the migrate-failure claim in the 11.32.4 guide

### DIFF
--- a/migration-guides/11.32.3-to-11.32.4.md
+++ b/migration-guides/11.32.3-to-11.32.4.md
@@ -39,10 +39,15 @@ It now verifies chunk completeness before resolving, and **rejects** when the fi
 (removing the incomplete file so retries do not accumulate orphans).
 
 **What you may notice:** a seed migration that previously "succeeded" while silently storing a broken
-asset now fails. Since `docker-entrypoint.sh` defaults to `MIGRATE_FAILURE_POLICY=abort`, that failure
-keeps the container from starting.
+asset now fails.
 
-**This is intentional** — finding exactly this is why migrations run before the server. To recover:
+**What that does to a deployment depends on the `docker-entrypoint.sh` your project copied — check
+yours.** The one shipped with this framework defaults to `MIGRATE_FAILURE_POLICY=abort` and keeps the
+container from starting. An older copy without that variable — including the one in
+`nest-server-starter` up to and including 11.32.4 — logs a warning and starts the server anyway, so
+the failure is visible only in the container log and the broken asset still ships.
+
+**Failing is intentional** — finding exactly this is why migrations run before the server. To recover:
 
 ```bash
 # 1. Identify the incomplete file from the migration error, which names it:


### PR DESCRIPTION
Doc-only follow-up to 11.32.4, so the guide linked from the release notes states the truth.

§1 claimed that a failed seed migration keeps the container from starting because `docker-entrypoint.sh` defaults to `MIGRATE_FAILURE_POLICY=abort`. That holds for the entrypoint shipped in this repo, but not for the one consumers actually copied: `nest-server-starter`'s entrypoint has no such variable and continues to server start after a failed migration, so for those projects the new fail-loud GridFS check is visible only in the container log — the opposite of what the guide promised.

No code changes.