### PR TITLE
docs: state the starter's migrate-failure default in the 11.32.4 guide

### DIFF
--- a/migration-guides/11.32.3-to-11.32.4.md
+++ b/migration-guides/11.32.3-to-11.32.4.md
@@ -42,10 +42,17 @@ It now verifies chunk completeness before resolving, and **rejects** when the fi
 asset now fails.
 
 **What that does to a deployment depends on the `docker-entrypoint.sh` your project copied — check
-yours.** The one shipped with this framework defaults to `MIGRATE_FAILURE_POLICY=abort` and keeps the
-container from starting. An older copy without that variable — including the one in
-`nest-server-starter` up to and including 11.32.4 — logs a warning and starts the server anyway, so
-the failure is visible only in the container log and the broken asset still ships.
+yours, and check its default.**
+
+| Your entrypoint | A failed migration |
+|-----------------|--------------------|
+| The one shipped with this framework | Refuses the start (`MIGRATE_FAILURE_POLICY` defaults to `abort`) |
+| From `nest-server-starter` 11.32.4 or newer | Starts the server anyway — the same variable exists, but it defaults to `warn`. Set `MIGRATE_FAILURE_POLICY=abort` per stage to refuse the start |
+| Older, without that variable | Starts the server anyway, with no way to change it short of updating the file |
+
+In the two lower rows the failure is visible only in the container log, and the broken asset still
+ships — so if you deploy from a starter-derived project, decide on `abort` explicitly rather than
+assuming this release stops a bad boot for you.
 
 **Failing is intentional** — finding exactly this is why migrations run before the server. To recover:
 


### PR DESCRIPTION
Doc-only follow-up, so the guide linked from the 11.32.4 release notes stays accurate.

`nest-server-starter` 11.32.4 gained a `MIGRATE_FAILURE_POLICY` switch that defaults to `warn` (unchanged behaviour, opt into `abort`). The guide's previous wording split entrypoints into 'has the variable' and 'does not', so a reader finding the variable in a starter-derived copy would conclude their container refuses to start on a failed migration — it does not. Replaced with a table that names the default per source.

No code changes.