### PR TITLE
11.34.1: honor custom validation messages and interpolate their placeholders

### DIFF
--- a/FRAMEWORK-API.md
+++ b/FRAMEWORK-API.md
@@ -1,6 +1,6 @@
 # @lenne.tech/nest-server — Framework API Reference
 
-> Auto-generated from source code on 2026-08-12 (v11.34.0)
+> Auto-generated from source code on 2026-08-14 (v11.34.1)
 > File: `FRAMEWORK-API.md` — compact, machine-readable API surface for Claude Code
 
 ## CoreModule.forRoot()

--- a/migration-guides/11.34.0-to-11.34.1.md
+++ b/migration-guides/11.34.0-to-11.34.1.md
@@ -1,0 +1,132 @@
+# Migration Guide: 11.34.0 → 11.34.1
+
+## Overview
+
+| Category | Details |
+|----------|---------|
+| **Breaking Changes** | None in signatures. One **client-visible text** change: validation error messages are now rendered the way class-validator itself renders them (§1, §2) |
+| **Bugfixes** | A custom `message` in `ValidationOptions` is no longer ignored (§1). Default messages no longer reach API clients with raw placeholders such as `$constraint1` (§2) |
+| **Migration Effort** | Nothing to configure. Read §1 and §2 if any test — or any frontend — asserts on exact validation error strings. Read §3 before you put `$value` in a custom message |
+
+`MapAndValidatePipe` re-implements class-validator's validation executor, so it also has to render
+error messages the way that executor does. It did neither: it built every message from the
+constraint's `defaultMessage()` alone, and substituted only `$property`.
+
+---
+
+## Quick Migration
+
+```bash
+pnpm update @lenne.tech/nest-server@11.34.1
+pnpm run build
+pnpm test
+```
+
+No configuration change is required, and no source change is required in a typical project.
+
+**Vendor-mode projects: this release ADDS a file, so the sync is atomic.**
+`src/core/common/pipes/map-and-validate.pipe.ts` now imports the new
+`src/core/common/helpers/validation-message.helper.ts`. Taking the pipe without the helper does not
+fail a rights check or a test — it fails the build. Sync both files together.
+
+---
+
+## 1. A custom `message` in `ValidationOptions` is now honored
+
+Previously the pipe built the message from the constraint's own `defaultMessage()` and never looked
+at `metadata.message`, so the message you wrote was silently discarded and the client received the
+generic default instead.
+
+```typescript
+class UpdateUserInput {
+  @IsIn(['admin'], { each: true, message: 'roles may only contain assignable roles (admin)' })
+  @IsOptional()
+  roles?: string[];
+}
+```
+
+| | Before | After |
+|---|---|---|
+| Response | `each value in roles must be one of the following values: $constraint1` | `roles may only contain assignable roles (admin)` |
+
+Custom messages now take precedence over the constraint's default — the same order class-validator's
+own executor uses. The function form (`message: (args) => string`) works too, and its result is
+interpolated afterwards.
+
+**What you may notice:** a custom message that was written but never delivered starts being
+delivered. If a frontend or a test was written against the *default* text your project was
+accidentally serving, it now sees the text the decorator actually asks for.
+
+---
+
+## 2. Default messages no longer leak raw placeholders
+
+Only `$property` was substituted, so every other token reached the client verbatim:
+
+| | Before | After |
+|---|---|---|
+| Response | `each value in roles must be one of the following values: $constraint1` | `each value in roles must be one of the following values: alpha, beta` |
+
+All four special tokens are now interpolated — `$constraint1..N`, `$value`, `$property` and
+`$target` — rendered exactly as class-validator renders them (arrays joined with `, `, symbols by
+their description).
+
+**Scope of the text change:** 44 of class-validator's built-in messages carry a `$constraint` token,
+so those 44 change text. None of the built-ins uses `$value` or `$target`, so no built-in message
+changes *shape* — they stop showing a placeholder and start showing the value it stood for.
+
+**What to check:** any test or frontend string comparison that asserts on a full validation message.
+A test that was pinned to the broken output (`…: $constraint1`) fails and should be updated to the
+interpolated text.
+
+This also applies to `@IsDefined`, which since class-validator 0.13 is the one built-in that does not
+register through `ValidateBy` and therefore took a separate code path with the same two gaps.
+
+---
+
+## 3. Security: `$value` echoes the submitted value, and validation errors are not scrubbed
+
+`$value` now works — which means a custom message containing it renders the value the client
+submitted, straight back into the error response.
+
+**Validation errors bypass the secret-field filtering you may be assuming.**
+`security.secretFields` is applied by `CheckSecurityInterceptor` on the **response** path, whereas
+the `BadRequestException` raised by the pipe goes to the exception filter and is forwarded verbatim.
+The guard inside the renderer is a **type** guard (`boolean | number | string`), not a secrecy guard
+— it will happily echo a password or a token.
+
+```typescript
+// DANGEROUS — the rejected password is echoed back in the error response
+@MinLength(12, { message: 'password "$value" is too short' })
+password: string;
+
+// SAFE — describe the rule, never the submitted value
+@MinLength(12, { message: 'password must be at least $constraint1 characters' })
+password: string;
+```
+
+No built-in message uses `$value`, so reaching this is opt-in: it requires a custom message that
+names the token. Note that class-validator's own `validate()` behaves identically — this is not a
+new exposure introduced by the framework, but it becomes reachable in projects where `$value`
+previously did nothing.
+
+**Action:** grep your input classes for `$value` in custom messages and confirm none of them sits on
+a credential, token, or otherwise sensitive field.
+
+---
+
+## Under the hood
+
+The token renderer is a port of class-validator internals
+(`ValidationUtils.replaceMessageSpecialTokens`, `constraintToString`), which are not part of its
+public API. Because vendor-mode projects resolve their own class-validator, that port can meet a
+version this framework never installed. It is therefore pinned by an invariant test that compares it
+against the installed implementation over a fixture table, so a divergence surfaces as a failing
+test rather than as two renderers disagreeing about one decorator.
+
+---
+
+## Module Documentation
+
+- Request lifecycle and the validation pipe: [`docs/REQUEST-LIFECYCLE.md`](../docs/REQUEST-LIFECYCLE.md)
+- Field decorators and validation: `src/core/common/decorators/unified-field.decorator.ts`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lenne.tech/nest-server",
-  "version": "11.34.0",
+  "version": "11.34.1",
   "description": "Modern, fast, powerful Node.js web framework in TypeScript based on Nest with a GraphQL API and a connection to MongoDB (or other databases).",
   "keywords": [
     "node",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   js-yaml@>=5.0.0 <5.2.2: 5.2.2
   fast-uri@>=3.0.0 <3.1.5: 3.1.5
   ip-address@<10.3.1: 10.3.1
-  nanoid@>=3.0.0 <3.3.17: 3.3.17
+  nanoid@>=3.0.0 <3.3.18: 3.3.18
   postcss@<8.5.23: 8.5.23
   undici@>=7.0.0 <7.29.0: 7.29.0
   hono@>=4.0.0 <4.12.34: 4.12.34
@@ -248,7 +248,7 @@ importers:
         version: 4.1.3
       bullmq:
         specifier: 6.0.9
-        version: 6.0.9(ioredis@6.0.0)
+        version: 6.0.9(ioredis@6.0.0(supports-color@5.5.0))
       find-file-up:
         specifier: 2.0.1
         version: 2.0.1
@@ -257,7 +257,7 @@ importers:
         version: 9.1.7
       ioredis:
         specifier: 6.0.0
-        version: 6.0.0
+        version: 6.0.0(supports-color@5.5.0)
       nodemon:
         specifier: 3.1.14
         version: 3.1.14
@@ -4154,8 +4154,8 @@ packages:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -7655,7 +7655,7 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  bullmq@6.0.9(ioredis@6.0.0):
+  bullmq@6.0.9(ioredis@6.0.0(supports-color@5.5.0)):
     dependencies:
       cron-parser: 5.7.0
       msgpackr: 2.0.5
@@ -7663,7 +7663,7 @@ snapshots:
       semver: 7.8.5
       tslib: 2.8.1
     optionalDependencies:
-      ioredis: 6.0.0
+      ioredis: 6.0.0(supports-color@5.5.0)
 
   busboy@1.6.0:
     dependencies:
@@ -8609,7 +8609,7 @@ snapshots:
       - supports-color
     optional: true
 
-  ioredis@6.0.0:
+  ioredis@6.0.0(supports-color@5.5.0):
     dependencies:
       '@ioredis/commands': 2.0.0
       cluster-key-slot: 1.1.1
@@ -9072,7 +9072,7 @@ snapshots:
 
   mute-stream@2.0.0: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   nanostores@1.1.1: {}
 
@@ -9349,7 +9349,7 @@ snapshots:
 
   postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -124,10 +124,13 @@ overrides:
   # via @modelcontextprotocol/sdk>express-rate-limit>ip-address.
   # Remove once express-rate-limit requests >=10.3.1.
   'ip-address@<10.3.1': '10.3.1'
-  # Security: nanoid predictable output with a non-integer size (high, patched >=3.3.17) - dev only,
+  # Security: TWO advisories on the 3.x line — predictable output with a non-integer size
+  # (patched >=3.3.17) and, since 2026-08, custom generators looping indefinitely when size
+  # is zero (high, patched >=3.3.18). The target is the LATER of the two; a 3.3.17 target
+  # closes the first and leaves the second open. Dev only,
   # transitive via better-auth>vitest>vite>postcss>nanoid. Separate line per major: 5.x is unaffected.
   # Remove once postcss requests >=3.3.17.
-  'nanoid@>=3.0.0 <3.3.17': '3.3.17'
+  'nanoid@>=3.0.0 <3.3.18': '3.3.18'
   # Security: postcss parsing DoS (moderate, patched >=8.5.23) - dev only, transitive via
   # better-auth>vitest>vite>postcss. Remove once vite requests >=8.5.23.
   'postcss@<8.5.23': '8.5.23'

--- a/spectaql.yml
+++ b/spectaql.yml
@@ -19,7 +19,7 @@ servers:
 info:
   title: lT Nest Server
   description: Modern, fast, powerful Node.js web framework in TypeScript based on Nest with a GraphQL API and a connection to MongoDB (or other databases).
-  version: 11.34.0
+  version: 11.34.1
   contact:
     name: lenne.Tech GmbH
     url: https://lenne.tech

--- a/src/core/common/helpers/validation-message.helper.ts
+++ b/src/core/common/helpers/validation-message.helper.ts
@@ -1,0 +1,83 @@
+import { ValidationArguments } from 'class-validator';
+
+/**
+ * Renders a single constraint for use in an error message.
+ *
+ * Mirror of class-validator's internal `constraintToString`
+ * (`class-validator/cjs/validation/ValidationUtils`), which is NOT part of its public API.
+ *
+ * See {@link replaceMessageSpecialTokens} for why this lives here and what holds it in sync.
+ */
+export function constraintToString(constraint: unknown): string {
+  if (Array.isArray(constraint)) {
+    return constraint.join(', ');
+  }
+  if (typeof constraint === 'symbol') {
+    constraint = constraint.description;
+  }
+  return `${constraint}`;
+}
+
+/**
+ * Resolves a message (string or function) and interpolates the special tokens
+ * $constraint1..N, $value, $property and $target.
+ *
+ * Mirror of class-validator's internal `ValidationUtils.replaceMessageSpecialTokens`
+ * (`class-validator/cjs/validation/ValidationUtils`), which is NOT part of its public API.
+ * `MapAndValidatePipe` re-implements the validation executor and therefore has to render messages
+ * exactly the way class-validator's own `validate()` would — otherwise the same decorator produces
+ * two different strings depending on which of the two ran.
+ *
+ * WHY IT IS NOT BARREL-EXPORTED
+ * Deliberately absent from `src/index.ts`. It exists to reproduce a dependency's internal
+ * behaviour, so it has to stay free to follow that dependency; exporting it would owe consumers
+ * backward compatibility for a surface we do not control. Vendor-mode consumers resolve their own
+ * class-validator, so the copy in `src/core/` can meet a version this repo never installed —
+ * `tests/unit/validation-message-mirror.spec.ts` compares it against the INSTALLED implementation
+ * over a fixture table so a divergence surfaces as a failing test rather than as two renderers of
+ * one contract.
+ *
+ * SECURITY — `$value` echoes the SUBMITTED value back to the client, and validation errors are
+ * never scrubbed: `security.secretFields` is applied by `CheckSecurityInterceptor` on the RESPONSE
+ * path, whereas the `BadRequestException` raised from the pipe goes to the exception filter and is
+ * forwarded verbatim. The check below is a TYPE guard (boolean | number | string), not a secrecy
+ * guard — it happily admits a password or a token. No built-in message uses `$value`, so reaching
+ * it is opt-in: never put `$value` in a custom message on a sensitive field.
+ */
+export function replaceMessageSpecialTokens(
+  message: ((args: ValidationArguments) => string) | string,
+  validationArguments: ValidationArguments,
+): string {
+  let messageString = '';
+  if (typeof message === 'function') {
+    messageString = message(validationArguments);
+  } else if (typeof message === 'string') {
+    messageString = message;
+  }
+
+  if (messageString && Array.isArray(validationArguments.constraints)) {
+    validationArguments.constraints.forEach((constraint, index) => {
+      messageString = messageString.replace(
+        new RegExp(`\\$constraint${index + 1}`, 'g'),
+        constraintToString(constraint),
+      );
+    });
+  }
+
+  if (
+    messageString &&
+    validationArguments.value !== undefined &&
+    validationArguments.value !== null &&
+    ['boolean', 'number', 'string'].includes(typeof validationArguments.value)
+  ) {
+    messageString = messageString.replace(/\$value/g, `${validationArguments.value}`);
+  }
+  if (messageString) {
+    messageString = messageString.replace(/\$property/g, validationArguments.property);
+  }
+  if (messageString) {
+    messageString = messageString.replace(/\$target/g, validationArguments.targetName);
+  }
+
+  return messageString;
+}

--- a/src/core/common/pipes/map-and-validate.pipe.ts
+++ b/src/core/common/pipes/map-and-validate.pipe.ts
@@ -20,6 +20,7 @@ import {
   maxLength,
   min,
   minLength,
+  ValidationArguments,
   ValidationError,
 } from 'class-validator';
 import { ValidationMetadata } from 'class-validator/types/metadata/ValidationMetadata';
@@ -53,6 +54,64 @@ function getPrototypeChain(target: any): Constructor[] {
   }
 
   return chain;
+}
+
+/**
+ * Renders a single constraint for use in an error message.
+ * Mirror of class-validator's internal `constraintToString` (not part of its public API).
+ */
+function constraintToString(constraint: unknown): string {
+  if (Array.isArray(constraint)) {
+    return constraint.join(', ');
+  }
+  if (typeof constraint === 'symbol') {
+    constraint = constraint.description;
+  }
+  return `${constraint}`;
+}
+
+/**
+ * Resolves a message (string or function) and interpolates the special tokens
+ * $constraint1..N, $value, $property and $target.
+ * Mirror of class-validator's internal `ValidationUtils.replaceMessageSpecialTokens`
+ * (not part of its public API).
+ */
+function replaceMessageSpecialTokens(
+  message: string | ((args: ValidationArguments) => string),
+  validationArguments: ValidationArguments,
+): string {
+  let messageString = '';
+  if (typeof message === 'function') {
+    messageString = message(validationArguments);
+  } else if (typeof message === 'string') {
+    messageString = message;
+  }
+
+  if (messageString && Array.isArray(validationArguments.constraints)) {
+    validationArguments.constraints.forEach((constraint, index) => {
+      messageString = messageString.replace(
+        new RegExp(`\\$constraint${index + 1}`, 'g'),
+        constraintToString(constraint),
+      );
+    });
+  }
+
+  if (
+    messageString &&
+    validationArguments.value !== undefined &&
+    validationArguments.value !== null &&
+    ['boolean', 'number', 'string'].includes(typeof validationArguments.value)
+  ) {
+    messageString = messageString.replace(/\$value/g, `${validationArguments.value}`);
+  }
+  if (messageString) {
+    messageString = messageString.replace(/\$property/g, validationArguments.property);
+  }
+  if (messageString) {
+    messageString = messageString.replace(/\$target/g, validationArguments.targetName);
+  }
+
+  return messageString;
 }
 
 /**
@@ -268,18 +327,21 @@ async function validateWithInheritance(object: any, originalPlainValue: any): Pr
                       isValid = validationResult instanceof Promise ? await validationResult : validationResult;
                     }
 
-                    // Get default message and constraint name if validation failed
+                    // Get message and constraint name if validation failed
                     if (!isValid) {
                       // Use metadata.name for the constraint key (e.g., "isEmail", "isString")
                       const constraintName = metadata.name || 'customValidation';
 
-                      if (typeof constraintInstance.defaultMessage === 'function') {
-                        errorMessage = constraintInstance.defaultMessage(validationArgs);
-                        // Replace $property placeholder with actual property name
-                        errorMessage = errorMessage.replace(/\$property/g, propertyName);
-                      } else {
-                        errorMessage = `${propertyName} failed custom validation`;
+                      // A custom message from ValidationOptions takes precedence over the
+                      // constraint's default message — same order as class-validator's executor
+                      let messageTemplate: string | ((args: ValidationArguments) => string) | undefined =
+                        metadata.message as string | ((args: ValidationArguments) => string) | undefined;
+                      if (!messageTemplate && typeof constraintInstance.defaultMessage === 'function') {
+                        messageTemplate = constraintInstance.defaultMessage(validationArgs);
                       }
+                      errorMessage = messageTemplate
+                        ? replaceMessageSpecialTokens(messageTemplate, validationArgs)
+                        : `${propertyName} failed custom validation`;
 
                       // Add to constraints with the proper name
                       propertyError.constraints[constraintName] = errorMessage;
@@ -578,6 +640,19 @@ async function validateWithInheritance(object: any, originalPlainValue: any): Pr
 
           // Add constraint violation if validation failed
           if (!isValid) {
+            // A custom message from ValidationOptions takes precedence over the built-in message
+            if (metadata.message) {
+              errorMessage = replaceMessageSpecialTokens(
+                metadata.message as string | ((args: ValidationArguments) => string),
+                {
+                  constraints: metadata.constraints || [],
+                  object: tempInstance,
+                  property: propertyName,
+                  targetName: targetClass.name,
+                  value: propertyValue,
+                },
+              );
+            }
             propertyError.constraints[constraintType] = errorMessage;
           }
         }

--- a/src/core/common/pipes/map-and-validate.pipe.ts
+++ b/src/core/common/pipes/map-and-validate.pipe.ts
@@ -28,6 +28,7 @@ import { inspect } from 'util';
 
 import { getUnifiedFieldKeys, nestedTypeRegistry } from '../decorators/unified-field.decorator';
 import { isBasicType } from '../helpers/input.helper';
+import { replaceMessageSpecialTokens } from '../helpers/validation-message.helper';
 import { ConfigService } from '../services/config.service';
 import { ErrorCode } from '../../modules/error-code/error-codes';
 
@@ -54,64 +55,6 @@ function getPrototypeChain(target: any): Constructor[] {
   }
 
   return chain;
-}
-
-/**
- * Renders a single constraint for use in an error message.
- * Mirror of class-validator's internal `constraintToString` (not part of its public API).
- */
-function constraintToString(constraint: unknown): string {
-  if (Array.isArray(constraint)) {
-    return constraint.join(', ');
-  }
-  if (typeof constraint === 'symbol') {
-    constraint = constraint.description;
-  }
-  return `${constraint}`;
-}
-
-/**
- * Resolves a message (string or function) and interpolates the special tokens
- * $constraint1..N, $value, $property and $target.
- * Mirror of class-validator's internal `ValidationUtils.replaceMessageSpecialTokens`
- * (not part of its public API).
- */
-function replaceMessageSpecialTokens(
-  message: string | ((args: ValidationArguments) => string),
-  validationArguments: ValidationArguments,
-): string {
-  let messageString = '';
-  if (typeof message === 'function') {
-    messageString = message(validationArguments);
-  } else if (typeof message === 'string') {
-    messageString = message;
-  }
-
-  if (messageString && Array.isArray(validationArguments.constraints)) {
-    validationArguments.constraints.forEach((constraint, index) => {
-      messageString = messageString.replace(
-        new RegExp(`\\$constraint${index + 1}`, 'g'),
-        constraintToString(constraint),
-      );
-    });
-  }
-
-  if (
-    messageString &&
-    validationArguments.value !== undefined &&
-    validationArguments.value !== null &&
-    ['boolean', 'number', 'string'].includes(typeof validationArguments.value)
-  ) {
-    messageString = messageString.replace(/\$value/g, `${validationArguments.value}`);
-  }
-  if (messageString) {
-    messageString = messageString.replace(/\$property/g, validationArguments.property);
-  }
-  if (messageString) {
-    messageString = messageString.replace(/\$target/g, validationArguments.targetName);
-  }
-
-  return messageString;
 }
 
 /**

--- a/tests/map-and-validate.pipe.e2e-spec.ts
+++ b/tests/map-and-validate.pipe.e2e-spec.ts
@@ -6,6 +6,7 @@ import {
   IsDefined,
   IsEmail,
   IsEnum,
+  IsIn,
   IsInt,
   IsNotEmpty,
   IsNumber,
@@ -1127,6 +1128,62 @@ describe('MapAndValidatePipe (comprehensive tests)', () => {
         const response = error.getResponse();
         expect(response).toHaveProperty('message');
         expect(response.message).toContain('Validation failed');
+      }
+    });
+
+    it('should honor a custom message from ValidationOptions', async () => {
+      // The custom message must win over the constraint's default message —
+      // same precedence as class-validator's own executor.
+      class CustomMessageInput {
+        @IsIn(['admin'], { each: true, message: 'roles may only contain assignable roles (admin)' })
+        @IsOptional()
+        roles?: string[];
+      }
+
+      try {
+        await pipe.transform({ roles: ['s_self'] }, { metatype: CustomMessageInput, type: 'body' });
+        throw new Error('Should have thrown BadRequestException');
+      } catch (error) {
+        expect(error).toBeInstanceOf(BadRequestException);
+        const response = error.getResponse();
+        expect(response.roles.isIn).toEqual('roles may only contain assignable roles (admin)');
+      }
+    });
+
+    it('should interpolate $constraint placeholders in default messages', async () => {
+      // Without a custom message, the default message must not leak raw
+      // placeholders like "$constraint1" to API clients.
+      class DefaultMessageInput {
+        @IsIn(['alpha', 'beta'], { each: true })
+        @IsOptional()
+        roles?: string[];
+      }
+
+      try {
+        await pipe.transform({ roles: ['gamma'] }, { metatype: DefaultMessageInput, type: 'body' });
+        throw new Error('Should have thrown BadRequestException');
+      } catch (error) {
+        expect(error).toBeInstanceOf(BadRequestException);
+        const response = error.getResponse();
+        expect(response.roles.isIn).toEqual('each value in roles must be one of the following values: alpha, beta');
+      }
+    });
+
+    it('should honor a custom message on non-ValidateBy constraints (isDefined)', async () => {
+      // isDefined is the one built-in that does not register as customValidation,
+      // so it takes the hardcoded-message code path.
+      class DefinedMessageInput {
+        @IsDefined({ message: 'name is required' })
+        name: string;
+      }
+
+      try {
+        await pipe.transform({}, { metatype: DefinedMessageInput, type: 'body' });
+        throw new Error('Should have thrown BadRequestException');
+      } catch (error) {
+        expect(error).toBeInstanceOf(BadRequestException);
+        const response = error.getResponse();
+        expect(response.name.isDefined).toEqual('name is required');
       }
     });
 

--- a/tests/map-and-validate.pipe.e2e-spec.ts
+++ b/tests/map-and-validate.pipe.e2e-spec.ts
@@ -1131,6 +1131,15 @@ describe('MapAndValidatePipe (comprehensive tests)', () => {
       }
     });
 
+    /**
+     * @regression   11.34.1 — MapAndValidatePipe built every message from
+     *   constraintInstance.defaultMessage() alone, so a custom `message` in ValidationOptions was
+     *   silently dropped: the developer wrote one string and the client received another.
+     * @seen-failing Drop the `metadata.message` initializer from `messageTemplate` in
+     *   src/core/common/pipes/map-and-validate.pipe.ts, so the default message wins again —
+     *   registered as mutation `validation-ignores-custom-message` in
+     *   tests/regression-mutations.json.
+     */
     it('should honor a custom message from ValidationOptions', async () => {
       // The custom message must win over the constraint's default message —
       // same precedence as class-validator's own executor.
@@ -1150,6 +1159,14 @@ describe('MapAndValidatePipe (comprehensive tests)', () => {
       }
     });
 
+    /**
+     * @regression   11.34.1 — only $property was substituted, so built-in default messages reached
+     *   API clients with the raw placeholder: "each value in roles must be one of the following
+     *   values: $constraint1".
+     * @seen-failing Disable the $constraint loop in `replaceMessageSpecialTokens()` in
+     *   src/core/common/helpers/validation-message.helper.ts — registered as mutation
+     *   `validation-message-placeholders-raw` in tests/regression-mutations.json.
+     */
     it('should interpolate $constraint placeholders in default messages', async () => {
       // Without a custom message, the default message must not leak raw
       // placeholders like "$constraint1" to API clients.
@@ -1169,6 +1186,15 @@ describe('MapAndValidatePipe (comprehensive tests)', () => {
       }
     });
 
+    /**
+     * @regression   11.34.1 — the custom-message gap also existed on the non-customValidation path.
+     *   Since class-validator 0.13 every other built-in registers via ValidateBy, so @IsDefined is
+     *   the one decorator that still reaches it — and its hardcoded message won over the
+     *   developer's.
+     * @seen-failing Delete the `if (metadata.message)` block from the built-in constraint branch in
+     *   src/core/common/pipes/map-and-validate.pipe.ts — registered as mutation
+     *   `validation-isdefined-ignores-custom-message` in tests/regression-mutations.json.
+     */
     it('should honor a custom message on non-ValidateBy constraints (isDefined)', async () => {
       // isDefined is the one built-in that does not register as customValidation,
       // so it takes the hardcoded-message code path.

--- a/tests/regression-mutations.json
+++ b/tests/regression-mutations.json
@@ -213,6 +213,52 @@
         "tests/unit/core-hub-db.service.spec.ts"
       ],
       "driverSpecific": false
+    },
+    {
+      "id": "validation-ignores-custom-message",
+      "defect": "11.34.1 — MapAndValidatePipe built every message from constraintInstance.defaultMessage() alone, so a custom `message` in ValidationOptions (IsIn([...], { message: '...' })) was silently dropped and the client saw the generic default instead.",
+      "file": "src/core/common/pipes/map-and-validate.pipe.ts",
+      "after": "const constraintName = metadata.name || 'customValidation';",
+      "find": "                      let messageTemplate: string | ((args: ValidationArguments) => string) | undefined =\n                        metadata.message as string | ((args: ValidationArguments) => string) | undefined;\n",
+      "replace": "                      let messageTemplate: string | ((args: ValidationArguments) => string) | undefined;\n",
+      "specs": [
+        "tests/map-and-validate.pipe.e2e-spec.ts"
+      ],
+      "driverSpecific": false
+    },
+    {
+      "id": "validation-message-placeholders-raw",
+      "defect": "11.34.1 — only $property was substituted, so built-in default messages reached API clients with raw placeholders: \"each value in roles must be one of the following values: $constraint1\".",
+      "file": "src/core/common/helpers/validation-message.helper.ts",
+      "find": "if (messageString && Array.isArray(validationArguments.constraints)) {",
+      "replace": "if (false && messageString && Array.isArray(validationArguments.constraints)) {",
+      "specs": [
+        "tests/map-and-validate.pipe.e2e-spec.ts"
+      ],
+      "driverSpecific": false
+    },
+    {
+      "id": "validation-isdefined-ignores-custom-message",
+      "defect": "11.34.1 — the same custom-message gap existed on the non-customValidation path, which since class-validator 0.13 is reached by @IsDefined alone: its hardcoded message won over the message the developer wrote.",
+      "file": "src/core/common/pipes/map-and-validate.pipe.ts",
+      "after": "          // Add constraint violation if validation failed",
+      "find": "            // A custom message from ValidationOptions takes precedence over the built-in message\n            if (metadata.message) {\n              errorMessage = replaceMessageSpecialTokens(\n                metadata.message as string | ((args: ValidationArguments) => string),\n                {\n                  constraints: metadata.constraints || [],\n                  object: tempInstance,\n                  property: propertyName,\n                  targetName: targetClass.name,\n                  value: propertyValue,\n                },\n              );\n            }\n",
+      "replace": "",
+      "specs": [
+        "tests/map-and-validate.pipe.e2e-spec.ts"
+      ],
+      "driverSpecific": false
+    },
+    {
+      "id": "validation-mirror-drops-target-token",
+      "defect": "11.34.1 — the message renderer is a port of class-validator internals, and a port drifts silently: vendor-mode consumers resolve their OWN class-validator, so src/core/ can meet a version this repo never installed. Dropping $target is the smallest such drift, and no e2e case reaches that token — only the mirror invariant test does.",
+      "file": "src/core/common/helpers/validation-message.helper.ts",
+      "find": "  if (messageString) {\n    messageString = messageString.replace(/\\$target/g, validationArguments.targetName);\n  }\n",
+      "replace": "",
+      "specs": [
+        "tests/unit/validation-message-mirror.spec.ts"
+      ],
+      "driverSpecific": false
     }
   ]
 }

--- a/tests/unit/validation-message-mirror.spec.ts
+++ b/tests/unit/validation-message-mirror.spec.ts
@@ -1,0 +1,246 @@
+/**
+ * Unit Tests: the local mirror of class-validator's message renderer must not drift from the
+ * installed class-validator.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `MapAndValidatePipe` re-implements class-validator's `ValidationExecutor`, so it also has to
+ * render error messages the way that executor does. 11.34.1 fixed it doing neither — a custom
+ * `message` was dropped, and `$constraint1` reached API clients raw. The fix ports two internal
+ * functions (`ValidationUtils.replaceMessageSpecialTokens`, `constraintToString`) into
+ * `src/core/common/helpers/validation-message.helper.ts`.
+ *
+ * A port is correct on the day it is written. What makes this one worth guarding is that
+ * VENDOR-MODE CONSUMERS RESOLVE THEIR OWN class-validator: `package.json` pins the version for
+ * this repo, but the copy of `src/core/` in a consumer's tree can meet 0.16 without anyone here
+ * touching anything. The failure is quiet by construction — the consumer's own `validate()` and
+ * the pipe render the SAME decorator differently, and only one of the two is under test anywhere.
+ *
+ * So this file asserts the invariant rather than the crash: for one fixture table, the mirror and
+ * the installed implementation must produce identical strings. It deep-imports
+ * `class-validator/cjs/validation/ValidationUtils`, which is not public API — normally a smell,
+ * here the entire point. `tests/` is never vendored and never shipped, so the deep import stays
+ * out of consumer trees. Precedent: `tests/unit/import-cycle-invariants.spec.ts`.
+ *
+ * @regression   11.34.1 — the pipe rendered messages from `defaultMessage()` alone and replaced
+ *   only `$property`, so custom messages were dropped and `$constraint1` leaked raw. The port that
+ *   fixed it is only as good as its agreement with upstream, which is what this file pins.
+ * @seen-failing Delete the `$target` replacement from `replaceMessageSpecialTokens()` in
+ *   src/core/common/helpers/validation-message.helper.ts — registered as mutation
+ *   `validation-mirror-drops-target-token` in tests/regression-mutations.json. That token is
+ *   reached by NO e2e case, so this mutation goes red here and nowhere else: it demonstrates the
+ *   coverage this file adds rather than merely re-proving the pipe spec.
+ */
+import { ValidationArguments } from 'class-validator';
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+
+import { constraintToString, replaceMessageSpecialTokens } from '../../src/core/common/helpers/validation-message.helper';
+
+/**
+ * The internals under comparison. Loaded through `createRequire` rather than an `import`, because
+ * class-validator ships type declarations under `types/` and runtime under `cjs/` — the deep
+ * runtime path has no `.d.ts` beside it and would not resolve as a typed ESM import.
+ */
+const requireCjs = createRequire(__filename);
+const upstream = requireCjs('class-validator/cjs/validation/ValidationUtils') as {
+  constraintToString: (constraint: unknown) => string;
+  ValidationUtils: {
+    replaceMessageSpecialTokens: (
+      message: ((args: ValidationArguments) => string) | string,
+      validationArguments: ValidationArguments,
+    ) => string;
+  };
+};
+
+function args(partial: Partial<ValidationArguments> = {}): ValidationArguments {
+  return {
+    constraints: [],
+    object: {},
+    property: 'roles',
+    targetName: 'UserInput',
+    value: undefined,
+    ...partial,
+  };
+}
+
+/**
+ * Every case declares its `expected` string, so the table doubles as documentation AND as a
+ * vacuity guard: a fixture that exercises no interpolation would show up here as an `expected`
+ * identical to its `message`, instead of hiding behind a trivially satisfied `mirror === upstream`.
+ */
+const CASES: { expected: string; message: ((args: ValidationArguments) => string) | string; name: string; validationArguments: ValidationArguments }[] = [
+  {
+    expected: 'must be one of the following values: alpha, beta',
+    message: 'must be one of the following values: $constraint1',
+    name: 'an array constraint renders comma-separated',
+    validationArguments: args({ constraints: [['alpha', 'beta']] }),
+  },
+  {
+    expected: 'must be between 1 and 10',
+    message: 'must be between $constraint1 and $constraint2',
+    name: 'multiple constraints are numbered in order',
+    validationArguments: args({ constraints: [1, 10] }),
+  },
+  {
+    expected: 'scope tenant',
+    message: 'scope $constraint1',
+    name: 'a symbol constraint renders its description',
+    validationArguments: args({ constraints: [Symbol('tenant')] }),
+  },
+  {
+    expected: 'scope undefined',
+    message: 'scope $constraint1',
+    name: 'a symbol constraint without a description renders "undefined"',
+    validationArguments: args({ constraints: [Symbol()] }),
+  },
+  {
+    expected: 'shape [object Object]',
+    message: 'shape $constraint1',
+    name: 'an object constraint falls back to string coercion (the shape a 0.16 could change)',
+    validationArguments: args({ constraints: [{ a: 1 }] }),
+  },
+  {
+    expected: 'got gamma',
+    message: 'got $value',
+    name: 'a string $value is echoed',
+    validationArguments: args({ value: 'gamma' }),
+  },
+  {
+    expected: 'got 7',
+    message: 'got $value',
+    name: 'a numeric $value is echoed',
+    validationArguments: args({ value: 7 }),
+  },
+  {
+    expected: 'got false',
+    message: 'got $value',
+    name: 'a boolean $value is echoed, false included',
+    validationArguments: args({ value: false }),
+  },
+  {
+    expected: 'got $value',
+    message: 'got $value',
+    name: 'a non-primitive $value is NOT echoed',
+    validationArguments: args({ value: { secret: 'x' } }),
+  },
+  {
+    expected: 'got $value',
+    message: 'got $value',
+    name: 'a null $value is NOT echoed',
+    validationArguments: args({ value: null }),
+  },
+  {
+    expected: 'got $value',
+    message: 'got $value',
+    name: 'an undefined $value is NOT echoed',
+    validationArguments: args({ value: undefined }),
+  },
+  {
+    expected: 'x a$valueb y',
+    message: 'x $value y',
+    name: 'a $value carrying a replacement pattern ($&) is inserted by the same rules on both sides',
+    validationArguments: args({ value: 'a$&b' }),
+  },
+  {
+    expected: 'roles is invalid',
+    message: '$property is invalid',
+    name: '$property is replaced',
+    validationArguments: args(),
+  },
+  {
+    expected: 'UserInput is invalid',
+    message: '$target is invalid',
+    name: '$target is replaced',
+    validationArguments: args(),
+  },
+  {
+    expected: 'roles roles roles',
+    message: '$property $property $property',
+    name: 'a repeated token is replaced everywhere, not just once',
+    validationArguments: args(),
+  },
+  {
+    expected: 'UserInput.roles rejected admin (allowed: a, b)',
+    message: '$target.$property rejected $value (allowed: $constraint1)',
+    name: 'all four token kinds in one message',
+    validationArguments: args({ constraints: [['a', 'b']], value: 'admin' }),
+  },
+  {
+    expected: 'roles must be one of: a, b',
+    message: (a: ValidationArguments) => `${a.property} must be one of: $constraint1`,
+    name: 'a function-form message is invoked and its result is then interpolated',
+    validationArguments: args({ constraints: [['a', 'b']] }),
+  },
+  {
+    expected: 'each value in roles must be one of the following values: alpha, beta',
+    message: 'each value in $property must be one of the following values: $constraint1',
+    name: 'the "each value in" prefix of a per-item default message survives interpolation',
+    validationArguments: args({ constraints: [['alpha', 'beta']] }),
+  },
+  {
+    expected: 'nothing to interpolate',
+    message: 'nothing to interpolate',
+    name: 'a message without tokens passes through unchanged',
+    validationArguments: args({ constraints: [['a']], value: 'x' }),
+  },
+  {
+    expected: '',
+    message: '',
+    name: 'an empty message stays empty',
+    validationArguments: args({ constraints: [['a']], value: 'x' }),
+  },
+  {
+    expected: 'unknown $constraint1',
+    message: 'unknown $constraint1',
+    name: 'a missing constraints array leaves $constraint tokens raw',
+    validationArguments: args({ constraints: undefined as unknown as any[] }),
+  },
+];
+
+describe('validation message mirror', () => {
+  describe('replaceMessageSpecialTokens matches the installed class-validator', () => {
+    it.each(CASES.map(entry => [entry.name, entry] as const))('%s', (_name, entry) => {
+      const mine = replaceMessageSpecialTokens(entry.message, entry.validationArguments);
+      const theirs = upstream.ValidationUtils.replaceMessageSpecialTokens(entry.message, entry.validationArguments);
+
+      // Both must render the DECLARED string. Asserting only `mine === theirs` would let a fixture
+      // that exercises nothing pass while proving nothing.
+      expect(theirs).toEqual(entry.expected);
+      expect(mine).toEqual(entry.expected);
+    });
+  });
+
+  describe('constraintToString matches the installed class-validator', () => {
+    const CONSTRAINTS: [string, unknown][] = [
+      ['an array', ['alpha', 'beta']],
+      ['an empty array', []],
+      ['a nested array', [['a', 'b'], 'c']],
+      ['a symbol', Symbol('tenant')],
+      ['a symbol without description', Symbol()],
+      ['a number', 42],
+      ['a string', 'plain'],
+      ['a boolean', true],
+      ['null', null],
+      ['undefined', undefined],
+      ['an object', { a: 1 }],
+    ];
+
+    it.each(CONSTRAINTS)('%s', (_name, constraint) => {
+      expect(constraintToString(constraint)).toEqual(upstream.constraintToString(constraint));
+    });
+  });
+
+  it('documents the one deliberate divergence, which no call site can reach', () => {
+    // Upstream initializes its accumulator as `undefined` and returns it untouched when the message
+    // is neither a string nor a function; the mirror initializes to '' and returns ''. Inert,
+    // because upstream's executor pre-normalizes (`metadata.message || ''`) and BOTH call sites in
+    // MapAndValidatePipe are guarded by a truthiness check on the template — so the argument is
+    // always a non-empty string or a function. Asserted rather than omitted: a divergence nobody
+    // writes down is indistinguishable from one nobody noticed.
+    const unreachable = undefined as unknown as string;
+
+    expect(upstream.ValidationUtils.replaceMessageSpecialTokens(unreachable, args())).toBeUndefined();
+    expect(replaceMessageSpecialTokens(unreachable, args())).toEqual('');
+  });
+});


### PR DESCRIPTION
Release **11.34.1** — a patch that makes validation error messages say what they are supposed to say.

## What is this?

`MapAndValidatePipe` re-implements class-validator's validation executor, so it also has to render error messages the way that executor does. It did neither: it built every message from the constraint's `defaultMessage()` alone and substituted only `$property`.

Two consequences reached every consumer:

- A custom `message` in `ValidationOptions` was **silently dropped** — the string you wrote never appeared in the response.
- Default messages arrived with **raw placeholders**: `each value in roles must be one of the following values: $constraint1`.

## How do I update?

```bash
pnpm update @lenne.tech/nest-server@11.34.1
pnpm run build
pnpm test
```

Nothing to configure.

## Do I need to do anything?

**Check any test or frontend that compares a full validation error string.** 44 of class-validator's built-in messages carry a `$constraint` token and therefore change text — they stop showing a placeholder and start showing the value it stood for. None of the built-ins uses `$value` or `$target`, so no message changes shape.

**If you wrote a custom message that never showed up, it now shows up.** A frontend or test pinned to the default text your project was accidentally serving will see the decorator's actual message instead.

**Grep your input classes for `$value` in custom messages.** That token now works, which means it echoes the submitted value into the error response — and validation errors are not scrubbed by `security.secretFields`, which only runs on the response path. Never put `$value` on a credential or token field. See §3 of the guide.

**Vendor-mode projects: sync two files together.** `src/core/common/pipes/map-and-validate.pipe.ts` now imports the new `src/core/common/helpers/validation-message.helper.ts`. Taking the pipe without the helper fails the build, not a test.

Full details: [`migration-guides/11.34.0-to-11.34.1.md`](migration-guides/11.34.0-to-11.34.1.md)

## Under the hood

The token renderer is a port of class-validator internals that are not public API, and vendor-mode projects resolve their own class-validator — so the port can meet a version this framework never installed. It is now pinned by an invariant test that compares it against the installed implementation over a fixture table. This release also raises the `nanoid` override to `>=3.3.18`, closing a second advisory on the 3.x line that the previous `3.3.17` target left open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
