### PR TITLE
docs(system-setup): the bootstrap claim also has to be dropped on a test reset

### DIFF
--- a/migration-guides/11.32.x-to-11.33.x.md
+++ b/migration-guides/11.32.x-to-11.33.x.md
@@ -547,9 +547,27 @@ creating, an instance now claims the setup by upserting `{ _id: 'initial-admin' 
 `system-setup-locks` collection — an atomic operation exactly one instance wins. The others log a
 debug line and skip. If creation then fails, the marker is removed so a later boot can retry.
 
-**Action: none.** The unique email index already prevented duplicate *users*; this removes the noisy
-failures and the ambiguity about which replica actually did the setup. A new collection
-`system-setup-locks` appears in the database with a single small document.
+**Action: none in production.** The unique email index already prevented duplicate *users*; this
+removes the noisy failures and the ambiguity about which replica actually did the setup. A new
+collection `system-setup-locks` appears in the database with a single small document.
+
+**Action if you reset the database to replay system setup — typically an E2E suite.** The marker is
+removed only when creation FAILS. After a SUCCESSFUL setup it stays, which is what you want for a
+deployment: setup must never run twice. But it also means that emptying `users` no longer restores
+the fresh-install state, because `createInitialAdmin()` now guards on two conditions, not one. The
+second `POST /system-setup/init` is then refused until the claim goes stale five minutes later.
+
+Drop the collection wherever you drop `users`:
+
+```typescript
+for (const col of ['users', 'system-setup-locks', /* … */]) {
+  await db.collection(col).deleteMany({});
+}
+```
+
+Both refusals raise the same `LTNS_0050`, whose message reads *"System setup not available - users
+already exist"* — so a suite hitting the claim is told the users are the problem while the users
+collection is empty. If setup fails right after a reset, check this collection before anything else.
 
 ---
 

--- a/src/core/modules/system-setup/README.md
+++ b/src/core/modules/system-setup/README.md
@@ -169,6 +169,9 @@ NEST_SERVER_CONFIG='{ "systemSetup": { "initialAdmin": { "email": "admin@example
   instance claims the setup by upserting the marker `{ _id: 'initial-admin' }` into the
   `system-setup-locks` collection — an atomic operation only one instance wins. The others log a
   debug message and skip. If creation fails, the marker is removed again so a later boot can retry.
+  After a SUCCESSFUL setup the marker REMAINS — setup must never run twice in a deployment. Test
+  suites that reset the database to replay the setup flow therefore have to drop `system-setup-locks`
+  alongside `users`; clearing only `users` leaves setup refused until the claim goes stale (5 min).
 
 ### Security Best Practices
 


### PR DESCRIPTION
## The gap

§5 of the 11.33 migration guide documents the new `system-setup-locks` marker and closes with **"Action: none."**

That is right for a deployment. It is wrong for any consumer whose test suite resets the database to replay the system-setup flow — and that case is both common and expensive to diagnose.

## Why

The marker is removed only when creation **fails**. After a successful setup it stays, which is the correct behaviour: setup must never run twice. But it means `createInitialAdmin()` now guards on **two** conditions, so emptying `users` no longer restores the fresh-install state. The next `POST /system-setup/init` is refused until the claim goes stale five minutes later.

What makes it hard to find is that both guards raise the same `LTNS_0050`, whose message reads *"System setup not available - users already exist"*. A suite that just emptied `users` is told that users are the problem, while the collection is empty.

## What it cost us

In `lt-crm` (52-spec Playwright suite, resets the DB per spec so setup is available again) this presented as:

- 33 of 52 specs failing, 94 failures hanging in `waitForURL` after the login click
- 4 passes across a 43-minute run — roughly one per five-minute stale window
- no server-side clue, because the API log was not archived in CI

The fix on our side was one collection name in the reset list. Finding it took a full CI cycle and a long process of elimination, because the error message named the wrong guard.

## This PR

Documentation only — no behaviour change. The current behaviour is right, just under-documented.

- `migration-guides/11.32.x-to-11.33.x.md` — §5 splits "Action: none in production" from the action a resetting test suite has to take, with a snippet and a pointer to the misleading message
- `src/core/modules/system-setup/README.md` — same consequence, three lines, next to the existing claim description

## Note on the message

Worth considering separately: the two guards sharing `LTNS_0050` with a message that only describes one of them is the actual trap. A distinct message for the claim path would have made this self-diagnosing. Happy to follow up if you want that — kept out of here to keep this docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)