### PR TITLE
fix(auth): a signed-in caller loses their identity on a public endpoint

### DIFF
--- a/src/core/modules/auth/guards/roles.guard.ts
+++ b/src/core/modules/auth/guards/roles.guard.ts
@@ -147,7 +147,14 @@ export class RolesGuard extends AuthGuard(AuthGuardStrategy.JWT) {
 
     // If no roles required, or S_EVERYONE is set, allow access without authentication
     // This allows public endpoints (without @Roles decorator or with S_EVERYONE) to work
+    //
+    // Access is granted either way, but the caller is still IDENTIFIED when they sent a valid
+    // token: returning early here left `request.user` unset, so a signed-in user hitting a
+    // public endpoint arrived as anonymous. Endpoints that are public AND personalise for
+    // signed-in callers — a search ranking by the caller's own location, a list marking the
+    // caller's own entries — silently lost that personalisation, with no error anywhere.
     if (!roles || !roles.some((value) => !!value) || roles.includes(RoleEnum.S_EVERYONE)) {
+      await this.tryIdentifyOptionalUser(context);
       return true;
     }
 
@@ -337,6 +344,43 @@ export class RolesGuard extends AuthGuard(AuthGuardStrategy.JWT) {
 
     // Everything is ok
     return user;
+  }
+
+  /**
+   * Identify the caller on a PUBLIC endpoint without ever denying access.
+   *
+   * Mirrors the authentication order of the protected path (Better-Auth first, Passport JWT
+   * second) but treats every failure as "anonymous" instead of raising: a missing, expired or
+   * malformed token must not turn a public endpoint into a 401. It only sets `request.user`,
+   * so `@CurrentUser()` and `serviceOptions.currentUser` see a signed-in caller again.
+   */
+  protected async tryIdentifyOptionalUser(context: ExecutionContext): Promise<void> {
+    try {
+      const request = this.getRequest(context);
+      if (!request || request.user) {
+        return;
+      }
+
+      this.resolveServices();
+
+      if (this.betterAuthService?.isEnabled()) {
+        const user = await this.verifyBetterAuthTokenFromContext(context);
+        if (user) {
+          request.user = user;
+          return;
+        }
+      }
+
+      const result = super.canActivate(context);
+      if (isObservable(result)) {
+        await firstValueFrom(result);
+      } else {
+        await result;
+      }
+    } catch {
+      // Deliberately silent — see the call site: on a public endpoint an unusable token means
+      // "anonymous", never an error.
+    }
   }
 
   /**


### PR DESCRIPTION
## The bug

`CoreRolesGuard.canActivate()` returns early for a public endpoint (`@Roles(S_EVERYONE)`, or no `@Roles`) **before any authentication runs**. Access is correct — but `request.user` is never set, so `@CurrentUser()` and `serviceOptions.currentUser` are `undefined` even when the request carried a valid token.

Every endpoint that is **public AND personalises for signed-in callers** silently degrades to anonymous. No error, no log.

## How it surfaced

Upgrading `regio-konnex` from 11.1.13 to 11.36.0. Its user search is `@Roles(S_EVERYONE)` on purpose — anonymous visitors may search — and ranks results by the distance to the **caller's own** company location. After the upgrade, `distance` and `distanceToCurrentUser` came back `null` for a signed-in caller.

Measured at the service boundary, with a valid token on the request:

```
EINTRITT currentUser typ: [object Undefined] | id: undefined | company? false
```

Changing **only** the decorator to `@Roles(S_USER)` made the same suite pass 40/40. That isolates the guard as the cause — and is also why it is not a fix: it would put a public endpoint behind a login.

## Why it looks unintended

Before the guard was reworked for Better-Auth, the `S_EVERYONE` branch was evaluated **after** the user had been resolved (11.5.0, `roles.guard.ts:52`):

```ts
if ((user && roles.includes(RoleEnum.S_USER)) || roles.includes(RoleEnum.S_EVERYONE))
```

so a signed-in caller kept their identity on a public route. No migration guide mentions the change — which fits an unintended side effect rather than a decision. If it *was* deliberate, this PR is the wrong fix and the guides should say so instead; happy to close it.

## The change

`tryIdentifyOptionalUser()` mirrors the authentication order of the protected path (Better-Auth first, Passport JWT second) and **swallows every failure**. A missing, expired or malformed token must not turn a public endpoint into a 401 — it simply stays anonymous, exactly as today.

Access control is untouched. Only identification is restored.

## Verification

`tsc --noEmit` is clean for this file. The two errors the run reports are pre-existing `toReversed` lib-target complaints in `tests/`, untouched here. I did not run the full suite — it needs the service containers — so please treat the runtime behaviour as reviewed-but-unproven on your side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)