### PR TITLE
docs(env): document the missing config surface in .env.example (S3, Redis, trustProxy, …)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -170,6 +170,59 @@ SMTP_PASS=smtp-password
 
 
 # =============================================================================
+# File storage — S3 / S3-compatible (optional, since 11.33)
+# =============================================================================
+# Files are served S3 → filesystem → GridFS, so switching is incremental: a file
+# is read from S3 as soon as its `s3-files` metadata document exists, everything
+# else keeps coming from where it is. No big-bang migration, no downtime window.
+#
+# WARNING — `NSC__S3__BUCKET` alone flips the storage driver. It makes S3 the
+# DERIVED default for `file.storage`, and the server then asserts the driver is
+# usable at boot. An app whose FileService still pins GridFS (`super(connection,
+# 'fs')`) stops with:
+#   "File storage 's3' was selected automatically (s3.bucket is configured) but
+#    is not available."
+# Do not configure S3 for a deployment before its code is ready for it.
+#
+# WARNING — NSC__ values are NOT parsed as JSON, but 'true'/'false' become
+# booleans and anything numeric becomes a NUMBER. An all-digit secret therefore
+# arrives as a number and the signature fails. Prefer keys with letters.
+
+# NSC__S3__BUCKET=my-app-files
+# NSC__S3__REGION=eu-central-1              # default 'us-east-1'
+
+# Credentials — omit both to use the AWS SDK default chain (env, instance
+# profile, IRSA, ...). Set them for S3-compatible providers.
+# NSC__S3__ACCESS_KEY_ID=
+# NSC__S3__SECRET_ACCESS_KEY=
+
+# S3-compatible services (MinIO, RustFS, STACKIT, Ceph) — omit for AWS S3.
+# Path-style addressing is required by most of them.
+# NSC__S3__ENDPOINT=https://object.storage.example.com
+# NSC__S3__FORCE_PATH_STYLE=true            # default false
+
+# Resumable TUS uploads are staged here before the finished object is moved into
+# `bucket`. Defaults to `bucket` — set it only if you want them separated.
+# NSC__S3__STAGING_BUCKET=my-app-uploads-staging
+
+# Create missing buckets at startup. Off by default: production buckets come
+# from infrastructure code, and their credentials usually cannot CreateBucket.
+# Either way the server verifies the buckets at boot and logs an actionable
+# error instead of failing the first upload with an opaque 500.
+# NSC__S3__AUTO_CREATE_BUCKET=true          # default false
+
+# Serve downloads as presigned redirects instead of streaming through the API.
+# The URL is a session-less BEARER CAPABILITY: once issued, anyone holding the
+# string can download until it expires — there is no revocation short of
+# deleting the object or rotating the credentials.
+# NSC__S3__PRESIGNED_DOWNLOADS=true                        # default false
+# NSC__S3__PRESIGNED_DOWNLOADS__EXPIRES_IN_SECONDS=300     # default 300
+
+# Pin the driver explicitly instead of relying on the derived default.
+# NSC__FILE__STORAGE=s3                     # 'filesystem' | 'gridfs' | 's3'
+
+
+# =============================================================================
 # Initial Admin (optional — first deployment only; remove after setup)
 # =============================================================================
 # Creates a single admin user on first startup if the user collection is empty.

--- a/.env.example
+++ b/.env.example
@@ -223,6 +223,96 @@ SMTP_PASS=smtp-password
 
 
 # =============================================================================
+# Redis — shared state for multiple replicas (optional, since 11.33)
+# =============================================================================
+# Used by every distributed feature: rate limiting, cron deduplication, GraphQL
+# subscriptions, caches and Hub collectors. Without it each replica keeps its own
+# state — rate limits count per instance and a cron job runs once PER REPLICA.
+# Presence implies enabled.
+
+# NSC__REDIS__HOST=redis
+# NSC__REDIS__PORT=6379
+# NSC__REDIS__DB=0
+# NSC__REDIS__USERNAME=
+# NSC__REDIS__PASSWORD=
+# NSC__REDIS__KEY_PREFIX=my-app             # default: the package name
+# Or as a single URL instead of the fields above:
+# NSC__REDIS__URL=redis://user:pass@redis:6379/0
+# NSC__REDIS__ENABLED=false                 # pre-configure without switching on
+
+
+# =============================================================================
+# Reverse proxy — required behind a load balancer / ingress
+# =============================================================================
+# Express `trust proxy`: how far up the `X-Forwarded-For` chain the app believes.
+# This is what makes `request.ip` correct, and EVERY IP-keyed rate limit depends
+# on it. Left unset behind a proxy, every request appears to come from the proxy,
+# so all clients share ONE rate-limit bucket — one noisy client throttles all of
+# them, and a per-IP limit protects nothing.
+#
+# Number = how many proxy hops to trust (1 for a single ingress).
+
+# NSC__TRUST_PROXY=1
+
+
+# =============================================================================
+# Input validation (since 11.16)
+# =============================================================================
+# Input properties NOT decorated with `@UnifiedField` are SILENTLY STRIPPED by
+# default. A plain `@Field` property on an input class never reaches the service:
+# no error, no warning, the value is simply gone — a sign-up carrying firstName
+# and lastName arrives with only email and password.
+#
+#   'strip' (default) — remove them silently
+#   'error'           — throw BadRequestException (LTNS_0303); use while porting
+#   false             — pre-11.16 behaviour, nothing is stripped
+#
+# Set `false` when migrating a large legacy input surface, and port the classes
+# to `@UnifiedField` afterwards.
+
+# NSC__SECURITY__MAP_AND_VALIDATE_PIPE__NON_WHITELISTED_FIELDS=error
+
+
+# =============================================================================
+# Graceful shutdown (optional, since 11.33)
+# =============================================================================
+# Delay between receiving the shutdown signal and starting the Nest shutdown
+# sequence. Gives the load balancer time to deregister the instance before
+# in-flight connections are drained — required for zero-downtime rollouts.
+
+# NSC__SHUTDOWN_DELAY_MS=5000
+
+
+# =============================================================================
+# Multi-tenancy (optional)
+# =============================================================================
+# Tenant isolation with membership validation. The active tenant comes from a
+# request header (default `x-tenant-id`), and queries are scoped by a mongoose
+# plugin. Turning this on changes what every query returns — verify against a
+# copy of the data first.
+
+# NSC__MULTI_TENANCY__ENABLED=true
+# NSC__MULTI_TENANCY__HEADER_NAME=x-tenant-id
+# NSC__MULTI_TENANCY__MEMBERSHIP_MODEL=TenantMember
+# NSC__MULTI_TENANCY__ADMIN_BYPASS=true     # platform admins see every tenant
+# NSC__MULTI_TENANCY__CACHE_TTL_MS=60000
+
+
+# =============================================================================
+# TUS resumable uploads (enabled by default)
+# =============================================================================
+# TUS is ON without any configuration. Since 11.33 it requires a session:
+# `tus.roles` defaults to `['s_user']`, not `s_everyone` — an anonymous upload
+# now answers 401 where it used to succeed.
+
+# NSC__TUS__ENABLED=false                   # switch it off entirely
+# NSC__TUS__PATH=tus
+# NSC__TUS__MAX_SIZE=104857600              # bytes
+# NSC__TUS__UPLOAD_DIR=./uploads-tus
+# NSC__TUS__S3_STAGING=true                 # stage in S3 instead of local disk
+
+
+# =============================================================================
 # Initial Admin (optional — first deployment only; remove after setup)
 # =============================================================================
 # Creates a single admin user on first startup if the user collection is empty.


### PR DESCRIPTION
## The gap

`.env.example` documents 17 of the 41 top-level `IServerOptions` keys. Of the 24 it does not, most are code-only (`execAfterInit`, `filter`, `sha256`, `ignoreSelectionsForPopulate`, …) and do not belong in an env file. **Seven do** — and several are things a consumer can only discover by reading `server-options.interface.ts` or by losing a day to the symptom.

Option names, shapes and defaults were read from the interfaces on `develop`, not from memory.

## The sharp ones

**`s3`** (11.33) — file storage was never mentioned at all. Two traps documented with it:
- `NSC__S3__BUCKET` alone flips the storage driver: it makes S3 the derived default for `file.storage`, and the server then asserts the driver is usable at boot. An app whose `FileService` still pins GridFS stops with *"File storage 's3' was selected automatically (s3.bucket is configured) but is not available."* A `.env.example` is exactly what invites setting the variable before the code is ready.
- `NSC__` values are not JSON, but they **are** coerced: `'true'`/`'false'` become booleans and anything numeric becomes a `Number`. An all-digit secret arrives as a number and the signature fails.

**`redis`** (11.33) — every distributed feature depends on it: rate limiting, cron deduplication, GraphQL subscriptions, caches, Hub collectors. Without it each replica keeps its own state, so a cron job runs once **per replica**.

**`trustProxy`** — what makes `request.ip` correct. Unset behind a proxy, every request appears to come from the proxy and all clients share **one** rate-limit bucket: one noisy client throttles everybody, and a per-IP limit protects nothing.

**`security.mapAndValidatePipe`** (11.16) — input properties without `@UnifiedField` are **silently stripped**. No error, no warning: a sign-up carrying `firstName` and `lastName` arrives with only `email` and `password`. We lost a working day to this in a consumer project before finding it at the service boundary. The `'error'` mode exists precisely to make it visible while porting, and is undocumented outside the interface.

## The rest

`shutdownDelayMs` (zero-downtime rollouts), `multiTenancy` (header-based isolation — turning it on changes what every query returns), and `tus` — enabled by default and, since 11.33, requiring a session (`roles` defaults to `['s_user']`), which turns previously working anonymous uploads into 401.

## Scope

Documentation only — no code, no defaults changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)