### PR TITLE
11.36.2: parallel regression-evidence gate

### DIFF
--- a/.claude/agent-memory/lt-dev-npm-package-maintainer/MEMORY.md
+++ b/.claude/agent-memory/lt-dev-npm-package-maintainer/MEMORY.md
@@ -78,6 +78,7 @@
 - `src/types/graphql-upload.d.ts` - custom type declarations for graphql-upload
 
 ## Index (topic files)
+- [pnpm 11 override + check gotchas](pnpm11-override-and-check-gotchas.md) — override keys match the REQUESTED range (bare key = downgrade lock); install keeps stale lock entries; `check --no-fix` protects uncommitted src/.
 - [Deferred major updates](deferred-major-updates.md) — better-auth 1.7 / graphql 17 / graphql-upload 18 / typescript 7 / pnpm pin: why each needs its own release.
 - [Override status](nest-server-override-status.md) — overrides live in pnpm-workspace.yaml; load-bearing vs inert, and the range-floored shape that makes an inert entry safe to keep.
 - [Maintenance gotchas](nest-server-maintenance-gotchas.md) — nest CLI exec bit, buffered pnpm output that fakes a hang, oxfmt drift check, depcheck false positives.

--- a/.claude/agent-memory/lt-dev-npm-package-maintainer/pnpm11-override-and-check-gotchas.md
+++ b/.claude/agent-memory/lt-dev-npm-package-maintainer/pnpm11-override-and-check-gotchas.md
@@ -1,0 +1,60 @@
+---
+name: pnpm11-override-and-check-gotchas
+description: pnpm 11 override-key semantics, lockfile stickiness after an override edit, and why `pnpm run check --no-fix` is the safe form when the tree has uncommitted src/ work
+metadata:
+  type: feedback
+---
+
+Three tool behaviours that cost time in the lt stack (nest-server + nest-server-starter,
+pnpm 11, `scripts/check.mjs`). All verified 2026-08-22 on pnpm 11.13.1.
+
+**1. An override key is matched against the REQUESTED RANGE, not the resolved version.**
+So `ip-address@<10.3.1` still fires for a consumer asking `^10.0.0` and pins the whole tree
+to the target. There is no "floor-only" override — every entry is a hard pin, and a target
+left behind the newest release in its major is a silent downgrade lock. A *bare* key
+(`hono: 4.12.25`) matches every range, so a bare + a ranged rule for the same package fight
+and the loser is invisible.
+**Why:** in the starter this produced `'@hono/node-server': 1.19.14` (below the CVE fix)
+sitting next to `'@hono/node-server@<2.0.10': 2.0.11` (above it) — audit green, config
+contradictory. Same shape had already bitten `fast-uri`.
+**How to apply:** one rule per package (per major line is fine, e.g. ws 7.x/8.x). The only
+honest test is TWO FRESH `--lockfile-only` resolves, one with the `overrides:` block and one
+without, then diff the resolved versions — diffing against the committed lockfile proves
+nothing, it already carries the pins. Procedure is now written up in the starter's
+`SECURITY.md` → "Verifying an override is still doing something".
+
+**2. `pnpm install` after editing overrides does NOT re-resolve everything.**
+It keeps existing lockfile entries that still satisfy the ranges, so a raised/removed
+override can leave the old version in place (`@hono/node-server` stayed 2.0.11 when a fresh
+resolve gives 2.1.1). Fix with a targeted `pnpm update --depth Infinity <pkg> [<pkg>...]`.
+Do NOT swap in the fresh-resolve lockfile wholesale — it also drifts unrelated transitives
+(kysely 0.28→0.29, nanostores 1.3→1.5 in one run), which is a much bigger, unreviewed change.
+
+**3. `pnpm run check` auto-fixes format + lint by default — it WRITES to `src/` and `tests/`.**
+When the working tree carries uncommitted source work (a release in progress), run
+`pnpm run check --no-fix` (read-only gate, same exit-code contract). It also runs
+`spectaql:sync`, which legitimately rewrites `spectaql.yml`'s version from `package.json` —
+expect that file in the diff on a release run.
+
+## Proving an override is a downgrade lock (technique, verified 2026-08-22 in lt-monorepo)
+
+A pnpm override key matches the **requested range**, not the resolved version — so a
+bounded key pins rather than floors. Probe that directly instead of assuming: add a key
+whose window the natural resolve does NOT satisfy (e.g. `'fast-xml-parser@<5.6.0': '5.9.0'`
+where the parent asks `^5.5.6` and the tree resolves 5.11.0). If it fires, the key is
+matched against the parent's declared range.
+
+The load-bearing test is **two fresh `--lockfile-only` resolves** from the same
+`package.json` in a scratch dir — one with `overrides:`, one with it stripped — then diff
+resolved versions and `pnpm audit` both. Strip `auditConfig.ignoreGhsas` in a third control,
+or a stale suppression hides the answer. Diffing against the COMMITTED lockfile proves
+nothing: it already carries the pinned versions.
+
+After changing an override, `pnpm install` alone keeps the stale entry ("Already up to date").
+`pnpm update <pkg>` moves that package but leaves its transitives stale; only
+`rm -rf node_modules pnpm-lock.yaml && pnpm install` yields a lockfile equal to a clean-room
+resolve. Verify by diffing the repo lockfile against a scratch `--lockfile-only` resolve.
+
+Also: an `auditConfig.ignoreGhsas` entry justified as "upstream range was never narrowed"
+must be re-checked against the live advisory — GitHub narrowed GHSA-mh99-v99m-4gvg to
+per-major windows, which silently made the suppression obsolete.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -233,10 +233,33 @@ pnpm run check:mutations                    # apply every registered mutation, r
 pnpm run check:mutations -- --id=<id>       # one mutation
 pnpm run check:mutations -- --list          # the registry, without running anything
 pnpm run check:mutations -- --allow-dirty   # when the fix and its evidence share a working tree
+pnpm run check:mutations -- --jobs=4        # N mutations at a time (default: 2, or 4 on >=12 cores)
 ```
 
 Not part of `pnpm run check` — it edits source and re-runs whole e2e suites. It belongs in review
-and on the publish path. Between runs the registry is kept from rotting by
+and on the publish path.
+
+### The cost is vitest's cold start, not the tests
+
+Worth knowing before optimising the wrong thing: the specs behind all 29 e2e mutations add up to
+**~40 seconds**. The step takes ~740s. The remaining ~700s is paying vitest's startup — process
+spawn, transform, module graph, mongod connect, DB create and drop — once per mutation, 49 times.
+That work is largely single-threaded I/O and barely scales with cores: the full registry measures
+**744s on a 12-core laptop and 777s on a 4-vCPU CI runner**.
+
+So it parallelises well, and `--jobs` does exactly that: **744s → 399s (1.87×) at 4 jobs**. Verified
+by diffing all 49 verdicts against a sequential run — a parallel mode that changes a verdict is not
+an optimisation, it is a broken safety net.
+
+**A mutation writes into the source tree**, which is why N cannot simply run at once: two mutations
+in one tree would see each other's edits and the specs would answer about a source state nobody
+registered. Each worker therefore gets its own `git worktree`, with `node_modules` symlinked from
+the main checkout (pnpm's internal links are relative, so one symlink serves every worktree).
+
+That isolation has a consequence: a worktree is at **HEAD**, so parallel mode tests COMMITTED code.
+When `src/` or `tests/` is dirty — or `--allow-dirty` is passed — the run says so and falls back to
+sequential. A fast answer about the wrong source is worse than a slow answer about the right one.
+`tests/unit/mutation-jobs-planning.spec.ts` pins that decision. Between runs the registry is kept from rotting by
 `tests/unit/regression-evidence.spec.ts`, which asserts every `find` still matches its target
 **exactly once**: a stale mutation would silently become a no-op, and a no-op "confirms" evidence
 that was never checked.

--- a/FRAMEWORK-API.md
+++ b/FRAMEWORK-API.md
@@ -1,6 +1,6 @@
 # @lenne.tech/nest-server — Framework API Reference
 
-> Auto-generated from source code on 2026-08-22 (v11.36.1)
+> Auto-generated from source code on 2026-08-22 (v11.36.2)
 > File: `FRAMEWORK-API.md` — compact, machine-readable API surface for Claude Code
 
 ## CoreModule.forRoot()

--- a/migration-guides/11.36.1-to-11.36.2.md
+++ b/migration-guides/11.36.1-to-11.36.2.md
@@ -1,0 +1,67 @@
+# Migration Guide: 11.36.1 → 11.36.2
+
+## Overview
+
+| Category | Details |
+|----------|---------|
+| **Breaking Changes** | None |
+| **New Features** | `check:mutations --jobs=N` — the regression-evidence gate now runs several mutations at once (§1) |
+| **Bugfixes** | None affecting runtime |
+| **Migration Effort** | **None.** Tooling-only release; nothing in `src/` changed |
+
+---
+
+## Quick Migration
+
+```bash
+pnpm update @lenne.tech/nest-server@11.36.2
+```
+
+That is the whole migration. This release changes no framework code, no configuration and no public
+API — `src/` is untouched. It is published so consuming projects stay on a current version and pick
+up the maintenance below.
+
+---
+
+## 1. Faster regression-evidence gate (framework repo only)
+
+Relevant if you run `pnpm run check:mutations`, or maintain a fork of this repo's tooling.
+
+`scripts/check-mutations.mjs` can now run several mutations in parallel:
+
+```bash
+pnpm run check:mutations                # auto: 2 workers, or 4 on a machine with >= 12 cores
+pnpm run check:mutations -- --jobs=4    # explicit
+pnpm run check:mutations -- --jobs=1    # force the previous sequential behaviour
+```
+
+**Measured: 744s → 399s (1.87×) at 4 jobs.** All 49 verdicts were diffed against a sequential run
+and are identical — a parallel mode that changes a verdict is a broken safety net, not a speedup.
+
+**Why it was slow in the first place, since it is easy to optimise the wrong thing:** the specs
+behind all 29 e2e mutations add up to about 40 seconds. The rest is paying vitest's cold start once
+per mutation, 49 times. That work is largely single-threaded I/O and barely scales with cores — the
+registry measures 744s on a 12-core laptop and 777s on a 4-vCPU CI runner.
+
+**How the isolation works.** A mutation writes into the source tree, so N cannot simply run at once:
+two mutations in one tree would see each other's edits. Each worker gets its own `git worktree`, with
+`node_modules` symlinked from the main checkout. A worktree is checked out at **HEAD**, so parallel
+mode tests committed code — when `src/` or `tests/` is dirty, or `--allow-dirty` is passed, the run
+prints why and falls back to sequential.
+
+---
+
+## 2. Dependency maintenance
+
+`@vitest/ui` was removed: no script passes `--ui` and no config imports it. Development-only, no
+runtime effect.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `check:mutations` prints "(sequential: …)" | `src/` or `tests/` is dirty, or `--allow-dirty` was passed | Intended — a worktree at HEAD would test different code. Commit or stash to get the fast path |
+| `check:mutations` seems slower than before | More workers than cores helps nothing; each worker starts a vitest that forks again | Lower `--jobs`, or leave it unset and let it size itself |
+| A stale worktree is left behind | The run was killed with SIGKILL | `git worktree prune` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lenne.tech/nest-server",
-  "version": "11.36.1",
+  "version": "11.36.2",
   "description": "Modern, fast, powerful Node.js web framework in TypeScript based on Nest with a GraphQL API and a connection to MongoDB (or other databases).",
   "keywords": [
     "node",
@@ -185,7 +185,6 @@
     "@types/nodemailer": "8.0.1",
     "@types/passport": "1.0.17",
     "@vitest/coverage-v8": "4.1.11",
-    "@vitest/ui": "4.1.11",
     "ansi-colors": "4.1.3",
     "bullmq": "6.2.0",
     "find-file-up": "2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,7 +150,7 @@ importers:
         version: 2.2.0
       node-mailjet:
         specifier: 6.0.11
-        version: 6.0.11
+        version: 6.0.11(supports-color@5.5.0)
       nodemailer:
         specifier: 9.0.5
         version: 9.0.5
@@ -239,9 +239,6 @@ importers:
       '@vitest/coverage-v8':
         specifier: 4.1.11
         version: 4.1.11(vitest@4.1.11)
-      '@vitest/ui':
-        specifier: 4.1.11
-        version: 4.1.11(vitest@4.1.11)
       ansi-colors:
         specifier: 4.1.3
         version: 4.1.3
@@ -301,7 +298,7 @@ importers:
         version: 8.0.0(@swc/core@1.16.1)(supports-color@5.5.0)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(terser@5.46.0)(tsx@4.23.12))
       vitest:
         specifier: 4.1.11
-        version: 4.1.11(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(terser@5.46.0)(tsx@4.23.12))
+        version: 4.1.11(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(terser@5.46.0)(tsx@4.23.12))
 
 packages:
 
@@ -2246,11 +2243,6 @@ packages:
   '@vitest/spy@4.1.11':
     resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
 
-  '@vitest/ui@4.1.11':
-    resolution: {integrity: sha512-r/rwyKoev21mWdRGSEkZOqkQ2BYy68mwjihg9M90nNRbf4NGrgzZ4cj6JNCEwlOGJkbKeMgsjlykvwKUbRr7gw==}
-    peerDependencies:
-      vitest: 4.1.11
-
   '@vitest/utils@4.1.11':
     resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
@@ -3223,9 +3215,6 @@ packages:
       picomatch:
         optional: true
 
-  fflate@0.8.2:
-    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
-
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
@@ -3257,9 +3246,6 @@ packages:
   find-versions@6.0.0:
     resolution: {integrity: sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA==}
     engines: {node: '>=18'}
-
-  flatted@3.4.2:
-    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
@@ -7117,7 +7103,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.11(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(terser@5.46.0)(tsx@4.23.12))
+      vitest: 4.1.11(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(terser@5.46.0)(tsx@4.23.12))
 
   '@vitest/expect@4.1.11':
     dependencies:
@@ -7153,17 +7139,6 @@ snapshots:
       pathe: 2.0.3
 
   '@vitest/spy@4.1.11': {}
-
-  '@vitest/ui@4.1.11(vitest@4.1.11)':
-    dependencies:
-      '@vitest/utils': 4.1.11
-      fflate: 0.8.2
-      flatted: 3.4.2
-      pathe: 2.0.3
-      sirv: 3.0.2
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vitest: 4.1.11(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(terser@5.46.0)(tsx@4.23.12))
 
   '@vitest/utils@4.1.11':
     dependencies:
@@ -7365,7 +7340,7 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
@@ -7466,11 +7441,11 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.19.0:
+  axios@1.19.0(supports-color@5.5.0):
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.6
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@5.5.0)
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -7516,7 +7491,7 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       mongodb: 7.5.0
-      vitest: 4.1.11(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(terser@5.46.0)(tsx@4.23.12))
+      vitest: 4.1.11(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(terser@5.46.0)(tsx@4.23.12))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -8208,8 +8183,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
-  fflate@0.8.2: {}
-
   figures@6.1.0:
     dependencies:
       is-unicode-supported: 2.1.0
@@ -8252,8 +8225,6 @@ snapshots:
     dependencies:
       semver-regex: 4.0.5
       super-regex: 1.1.0
-
-  flatted@3.4.2: {}
 
   follow-redirects@1.16.0: {}
 
@@ -8493,9 +8464,9 @@ snapshots:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@5.5.0):
     dependencies:
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@5.5.0)
       debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
@@ -9031,9 +9002,9 @@ snapshots:
 
   node-gyp-build@4.8.4: {}
 
-  node-mailjet@6.0.11:
+  node-mailjet@6.0.11(supports-color@5.5.0):
     dependencies:
-      axios: 1.19.0
+      axios: 1.19.0(supports-color@5.5.0)
       json-bigint: 1.0.0
       url-join: 4.0.1
     transitivePeerDependencies:
@@ -10013,7 +9984,7 @@ snapshots:
       terser: 5.46.0
       tsx: 4.23.12
 
-  vitest@4.1.11(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(terser@5.46.0)(tsx@4.23.12)):
+  vitest@4.1.11(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(terser@5.46.0)(tsx@4.23.12)):
     dependencies:
       '@vitest/expect': 4.1.11
       '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(terser@5.46.0)(tsx@4.23.12))
@@ -10038,7 +10009,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.2.0
       '@vitest/coverage-v8': 4.1.11(vitest@4.1.11)
-      '@vitest/ui': 4.1.11(vitest@4.1.11)
     transitivePeerDependencies:
       - msw
 

--- a/scripts/check-mutations.mjs
+++ b/scripts/check-mutations.mjs
@@ -38,9 +38,33 @@
  *   pnpm run check:mutations -- --id=<id>       one mutation
  *   pnpm run check:mutations -- --list          show the registry without running anything
  *   pnpm run check:mutations -- --allow-dirty   run against an uncommitted working tree
+ *   pnpm run check:mutations -- --jobs=4        run 4 mutations at a time (see below)
+ *
+ * PARALLELISM
+ * -----------
+ * The work here is not the tests — the whole registry's specs add up to well under a minute. It is
+ * paying vitest's cold start (process spawn, transform, module graph, mongod connect, DB create and
+ * drop) once per mutation. That is idle-core time, so it parallelises well.
+ *
+ * A mutation WRITES INTO THE SOURCE TREE, which is why this cannot simply run N at once: two
+ * mutations in one tree would see each other's edits, and the specs would be answering about a
+ * source state nobody registered. So each worker gets its own `git worktree` (with `node_modules`
+ * symlinked from the main checkout — pnpm's internal links are relative, so this works and costs
+ * nothing) and mutates only inside it.
+ *
+ * That isolation has a consequence worth stating: a worktree is checked out at HEAD, so parallel
+ * mode tests COMMITTED code. When the working tree is dirty — or `--allow-dirty` is passed, which
+ * is exactly the "fix and its evidence share a tree" case — the run falls back to sequential, where
+ * the real working tree is what gets mutated. Getting a fast answer about the wrong source is worse
+ * than a slow answer about the right one.
+ *
+ * `--jobs` defaults to a value derived from the core count, capped at 4: each worker starts a vitest
+ * that forks again, so oversubscribing costs more than it buys. `--jobs=1` forces the sequential
+ * path, byte-for-byte the behaviour that existed before parallelism was added.
  */
-import { spawnSync } from 'node:child_process';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { availableParallelism, tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -51,6 +75,7 @@ const args = process.argv.slice(2);
 const only = args.find((arg) => arg.startsWith('--id='))?.slice('--id='.length);
 const listOnly = args.includes('--list');
 const allowDirty = args.includes('--allow-dirty');
+const jobsArg = args.find((arg) => arg.startsWith('--jobs='))?.slice('--jobs='.length);
 
 /** Files restored on any exit path, keyed by absolute path. */
 const originals = new Map();
@@ -104,18 +129,237 @@ function gitIsClean(file) {
   return result.status === 0 && result.stdout.trim() === '';
 }
 
-function runSpecs(specs) {
+function specEnv(specs, jobs) {
   const unit = specs.every((spec) => spec.startsWith('tests/unit/'));
-  const config = unit ? 'vitest.config.ts' : 'vitest-e2e.config.ts';
-  const result = spawnSync('npx', ['vitest', 'run', '--config', config, ...specs], {
-    cwd: ROOT,
-    encoding: 'utf8',
-    env: { ...process.env, CHECK_LOW_RESOURCE: process.env.CHECK_LOW_RESOURCE ?? '0', NODE_ENV: unit ? 'test' : 'e2e' },
-  });
-  return { code: result.status ?? 1, output: `${result.stdout ?? ''}${result.stderr ?? ''}` };
+  return {
+    ...process.env,
+    CHECK_LOW_RESOURCE: process.env.CHECK_LOW_RESOURCE ?? '0',
+    // Every worker runs its own e2e vitest, and the machine-wide run governor would otherwise make
+    // them queue behind each other — turning the parallel run back into a sequential one with extra
+    // steps. These workers ARE one coordinated run, so raise the cap to fit them.
+    ...(jobs > 1 ? { LT_E2E_MAX_RUNS: String(Math.max(jobs, Number(process.env.LT_E2E_MAX_RUNS) || 0)) } : {}),
+    NODE_ENV: unit ? 'test' : 'e2e',
+  };
 }
 
-function main() {
+function specConfig(specs) {
+  return specs.every((spec) => spec.startsWith('tests/unit/')) ? 'vitest.config.ts' : 'vitest-e2e.config.ts';
+}
+
+/**
+ * Run a mutation's specs.
+ *
+ * Deliberately `spawn` and not `spawnSync`: `spawnSync` blocks the whole event loop, so a
+ * `Promise.all` over several of them executes strictly one after another. The parallel path would
+ * have looked parallel, taken exactly as long as the sequential one, and nothing would have said so.
+ */
+function runSpecs(specs, cwd = ROOT, jobs = 1) {
+  return new Promise((resolveRun) => {
+    const child = spawn('npx', ['vitest', 'run', '--config', specConfig(specs), ...specs], {
+      cwd,
+      env: specEnv(specs, jobs),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let output = '';
+    child.stdout.on('data', (chunk) => (output += chunk));
+    child.stderr.on('data', (chunk) => (output += chunk));
+    child.on('error', (error) => resolveRun({ code: 1, output: `${output}\n${error.message}` }));
+    child.on('close', (code) => resolveRun({ code: code ?? 1, output }));
+  });
+}
+
+/** Worktrees created for a parallel run — removed on every exit path. */
+const worktrees = [];
+
+function removeWorktrees() {
+  for (const dir of worktrees.splice(0)) {
+    try {
+      spawnSync('git', ['worktree', 'remove', '--force', dir], { cwd: ROOT });
+      if (existsSync(dir)) rmSync(dir, { force: true, recursive: true });
+    } catch {
+      process.stderr.write(`\n!! Could not remove worktree ${dir} — run \`git worktree prune\`\n`);
+    }
+  }
+}
+
+process.on('exit', removeWorktrees);
+
+/**
+ * How many mutations to run at once.
+ *
+ * Capped at 4 because each worker starts a vitest that forks again — past that the workers fight
+ * each other for the same cores and the wall clock stops improving. Falls back to sequential
+ * whenever the worktree would not be a faithful stand-in for what the caller wants tested.
+ */
+/**
+ * Decide how many mutations to run at once — pure, so the decision can be tested without a repo,
+ * worktrees and seven minutes. See `tests/unit/mutation-jobs-planning.spec.ts`.
+ *
+ * @param {object} options
+ * @param {boolean} [options.allowDirty] `--allow-dirty` was passed
+ * @param {number} options.cores available parallelism
+ * @param {number} [options.explicit] `--jobs=N`, `NaN` when absent or malformed
+ * @param {number} options.mutationCount how many mutations this run will apply
+ * @param {boolean} [options.sourceDirty] `src/` or `tests/` has uncommitted changes
+ * @returns {{ jobs: number, why?: string }} `why` is set only when it fell back to sequential
+ */
+export function planJobs({
+  allowDirty: dirtyAllowed = false,
+  cores,
+  explicit = Number.NaN,
+  mutationCount,
+  sourceDirty = false,
+}) {
+  // Floor of 2, not 1: the dominant cost is vitest's cold start, which is largely single-threaded
+  // I/O and does NOT scale with cores — the full registry takes ~744s on a 12-core laptop and ~777s
+  // on a 4-vCPU CI runner. A core-proportional formula would therefore hand the smallest runner no
+  // parallelism at all, which is exactly where the wall clock is worth reclaiming. Capped at 4
+  // because each worker starts a vitest that forks again; measured 744s -> 399s (1.87x) at 4 jobs
+  // on 12 cores, so the scaling is real but sub-linear and more workers stop paying.
+  const requested =
+    Number.isInteger(explicit) && explicit > 0 ? explicit : Math.min(4, Math.max(2, Math.floor(cores / 3)));
+  if (requested === 1 || mutationCount < 2) return { jobs: 1 };
+
+  // A worktree is checked out at HEAD. If the caller is testing uncommitted work, that is the wrong
+  // source — answer slowly about the right code rather than quickly about the wrong code.
+  if (dirtyAllowed) {
+    return { jobs: 1, why: '--allow-dirty tests the working tree, which a worktree at HEAD is not' };
+  }
+  if (sourceDirty) {
+    return { jobs: 1, why: 'src/ or tests/ is dirty, so HEAD would not be what you are testing' };
+  }
+  return { jobs: Math.min(requested, mutationCount) };
+}
+
+function resolveJobs(mutations) {
+  // Scoped to what can actually change a verdict: the code a mutation edits and the specs that
+  // judge it. A dirty README or a package.json bump cannot, and refusing to parallelise over those
+  // would mean the fast path is almost never available in a real working session.
+  const dirty = spawnSync('git', ['status', '--porcelain', '--', 'src', 'tests'], { cwd: ROOT, encoding: 'utf8' });
+  const { jobs, why } = planJobs({
+    allowDirty,
+    cores: availableParallelism(),
+    explicit: Number(jobsArg),
+    mutationCount: mutations.length,
+    sourceDirty: Boolean((dirty.stdout ?? '').trim()),
+  });
+  if (why) process.stdout.write(`   (sequential: ${why})\n`);
+  return jobs;
+}
+
+/**
+ * Run the registry across `jobs` worktrees.
+ *
+ * Output is assembled in REGISTRY order, not completion order — a run whose report reshuffles
+ * itself depending on machine timing is a run nobody can diff against the last one.
+ */
+function runParallel(mutations, jobs) {
+  const base = mkdtempSync(join(tmpdir(), 'lt-mutations-'));
+  process.stdout.write(`\nRunning ${mutations.length} mutations across ${jobs} worktrees\n`);
+
+  const lanes = [];
+  for (let i = 0; i < jobs; i++) {
+    const dir = join(base, `w${i}`);
+    const added = spawnSync('git', ['worktree', 'add', '--detach', dir, 'HEAD'], { cwd: ROOT, encoding: 'utf8' });
+    if (added.status !== 0) {
+      removeWorktrees();
+      process.stderr.write(`\n!! Could not create worktree: ${added.stderr ?? ''}\nFalling back to sequential.\n`);
+      return mutations.map((mutation) => runOne(mutation, ROOT, 1, true));
+    }
+    worktrees.push(dir);
+    // pnpm's internal links are relative to node_modules, so one symlink serves every worktree —
+    // no second install, no store duplication.
+    symlinkSync(join(ROOT, 'node_modules'), join(dir, 'node_modules'));
+    lanes.push(dir);
+  }
+
+  // Round-robin rather than contiguous slices: the expensive mutations are the e2e ones and they
+  // cluster together in the registry, so a contiguous split would hand one worker all of them.
+  const assigned = mutations.map((mutation, index) => ({ index, lane: index % jobs, mutation }));
+  const settled = Array.from({ length: mutations.length });
+  let done = 0;
+  const workers = lanes.map((dir, lane) =>
+    (async () => {
+      for (const item of assigned.filter((entry) => entry.lane === lane)) {
+        // `await` is load-bearing: without it this assigns the PENDING PROMISE, the lane never
+        // waits, and all N mutations launch at once instead of N-at-a-time. The progress counter
+        // then counts promises and reports a run that has not happened yet.
+        settled[item.index] = await runOne(item.mutation, dir, jobs, false);
+        done += 1;
+        process.stdout.write(`   [${done}/${mutations.length}] ${item.mutation.id}\n`);
+      }
+    })(),
+  );
+
+  return Promise.all(workers).then(() => {
+    removeWorktrees();
+    for (const result of settled) process.stdout.write(result.log.join(''));
+    return settled;
+  });
+}
+
+/**
+ * Run ONE mutation inside `cwd` and report whether its specs went red.
+ *
+ * Shared by the sequential and the parallel paths so the two cannot drift into answering the
+ * question differently — the verdict logic exists once.
+ *
+ * `live` distinguishes the two callers: the sequential path mutates the developer's real working
+ * tree, so it honours the dirty-file guard and registers the snapshot with the process-wide restore
+ * handler. A worktree is disposable and checked out at HEAD, so neither applies there.
+ */
+async function runOne(mutation, cwd, jobs, live) {
+  const file = resolve(cwd, mutation.file);
+  const log = [`\n── ${mutation.id} ──\n   ${mutation.file}\n`];
+  const emit = (line) => {
+    log.push(line);
+    if (jobs === 1) process.stdout.write(line);
+  };
+
+  if (live && !allowDirty && !gitIsClean(mutation.file)) {
+    emit('   SKIPPED: uncommitted changes in the target file (--allow-dirty to override)\n');
+    return {
+      id: mutation.id,
+      log,
+      note: 'target file has uncommitted changes — re-run with --allow-dirty if that is expected',
+      ok: false,
+    };
+  }
+
+  const original = readFileSync(file, 'utf8');
+  let mutated;
+  try {
+    mutated = applyMutation(original, mutation);
+  } catch (error) {
+    emit(`   STALE: ${error.message}\n`);
+    return { id: mutation.id, log, note: `mutation is stale: ${error.message}`, ok: false };
+  }
+
+  if (live) originals.set(file, original);
+  try {
+    // Last-moment race check. Between reading the snapshot and writing the mutation another
+    // process (a parallel agent, a watch-mode formatter) may have rewritten the file; restoring
+    // the snapshot afterwards would silently discard that edit.
+    if (readFileSync(file, 'utf8') !== original) {
+      throw new Error('the target file changed while this mutation was being prepared');
+    }
+    writeFileSync(file, mutated);
+    emit(`   applied, running ${mutation.specs.join(' ')}\n`);
+    const { code, output } = await runSpecs(mutation.specs, cwd, jobs);
+    const failedCount = output.match(/Tests\s+(\d+) failed/)?.[1];
+    if (code === 0) {
+      emit('   VACUOUS: the specs passed with the defect restored\n');
+      return { id: mutation.id, log, note: 'specs stayed GREEN with the defect restored — vacuous', ok: false };
+    }
+    emit(`   OK: ${failedCount ?? 'some'} test(s) went red\n`);
+    return { id: mutation.id, log, note: `${failedCount ?? 'some'} test(s) failed, as required`, ok: true };
+  } finally {
+    writeFileSync(file, original);
+    if (live) originals.delete(file);
+  }
+}
+
+async function main() {
   const registry = JSON.parse(readFileSync(REGISTRY, 'utf8'));
   const mutations = registry.mutations.filter((mutation) => !only || mutation.id === only);
 
@@ -133,54 +377,14 @@ function main() {
     return;
   }
 
-  const results = [];
-
-  for (const mutation of mutations) {
-    const file = resolve(ROOT, mutation.file);
-    process.stdout.write(`\n── ${mutation.id} ──\n   ${mutation.file}\n`);
-
-    if (!allowDirty && !gitIsClean(mutation.file)) {
-      results.push({
-        id: mutation.id,
-        note: 'target file has uncommitted changes — re-run with --allow-dirty if that is expected',
-        ok: false,
-      });
-      process.stdout.write('   SKIPPED: uncommitted changes in the target file (--allow-dirty to override)\n');
-      continue;
-    }
-
-    const original = readFileSync(file, 'utf8');
-    let mutated;
-    try {
-      mutated = applyMutation(original, mutation);
-    } catch (error) {
-      results.push({ id: mutation.id, note: `mutation is stale: ${error.message}`, ok: false });
-      process.stdout.write(`   STALE: ${error.message}\n`);
-      continue;
-    }
-
-    originals.set(file, original);
-    try {
-      // Last-moment race check. Between reading the snapshot and writing the mutation another
-      // process (a parallel agent, a watch-mode formatter) may have rewritten the file; restoring
-      // the snapshot afterwards would silently discard that edit.
-      if (readFileSync(file, 'utf8') !== original) {
-        throw new Error('the target file changed while this mutation was being prepared');
-      }
-      writeFileSync(file, mutated);
-      process.stdout.write(`   applied, running ${mutation.specs.join(' ')}\n`);
-      const { code, output } = runSpecs(mutation.specs);
-      const failedCount = output.match(/Tests\s+(\d+) failed/)?.[1];
-      if (code === 0) {
-        results.push({ id: mutation.id, note: 'specs stayed GREEN with the defect restored — vacuous', ok: false });
-        process.stdout.write('   VACUOUS: the specs passed with the defect restored\n');
-      } else {
-        results.push({ id: mutation.id, note: `${failedCount ?? 'some'} test(s) failed, as required`, ok: true });
-        process.stdout.write(`   OK: ${failedCount ?? 'some'} test(s) went red\n`);
-      }
-    } finally {
-      writeFileSync(file, original);
-      originals.delete(file);
+  const jobs = resolveJobs(mutations);
+  let results;
+  if (jobs > 1) {
+    results = await runParallel(mutations, jobs);
+  } else {
+    results = [];
+    for (const mutation of mutations) {
+      results.push(await runOne(mutation, ROOT, 1, true));
     }
   }
 

--- a/spectaql.yml
+++ b/spectaql.yml
@@ -19,7 +19,7 @@ servers:
 info:
   title: lT Nest Server
   description: Modern, fast, powerful Node.js web framework in TypeScript based on Nest with a GraphQL API and a connection to MongoDB (or other databases).
-  version: 11.36.1
+  version: 11.36.2
   contact:
     name: lenne.Tech GmbH
     url: https://lenne.tech

--- a/tests/unit/mutation-jobs-planning.spec.ts
+++ b/tests/unit/mutation-jobs-planning.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * How `check:mutations` decides between the parallel and the sequential path.
+ *
+ * WHY THIS IS TESTED AT ALL
+ * -------------------------
+ * The mutation runner is the thing that proves the regression tests are not vacuous. If it silently
+ * answers about the WRONG SOURCE, every verdict it prints is worthless — and the two ways that can
+ * happen are both decided here: parallel mode runs each mutation in a `git worktree` checked out at
+ * HEAD, so it must refuse to parallelise whenever the caller is testing uncommitted work.
+ *
+ * The rest of the runner needs a real repo, real worktrees and ~7 minutes. This decision does not,
+ * so it is worth pinning on its own.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { planJobs } from '../../scripts/check-mutations.mjs';
+
+const clean = { cores: 12, mutationCount: 49 };
+
+describe('planJobs', () => {
+  describe('falls back to sequential when a worktree would test the wrong source', () => {
+    it('refuses to parallelise a dirty src/ or tests/', () => {
+      // A worktree is at HEAD. Parallelising here would give a fast answer about code the caller is
+      // not running — strictly worse than a slow answer about the code they are.
+      const { jobs, why } = planJobs({ ...clean, sourceDirty: true });
+
+      expect(jobs).toBe(1);
+      expect(why).toMatch(/dirty/);
+    });
+
+    it('refuses to parallelise under --allow-dirty', () => {
+      // --allow-dirty exists for "the fix and its evidence share a working tree", which is exactly
+      // the case a HEAD worktree cannot represent.
+      const { jobs, why } = planJobs({ ...clean, allowDirty: true });
+
+      expect(jobs).toBe(1);
+      expect(why).toMatch(/working tree/);
+    });
+
+    it('says WHY it went sequential', () => {
+      // Silence here would look identical to "this machine is just slow".
+      expect(planJobs({ ...clean, sourceDirty: true }).why).toBeTruthy();
+    });
+  });
+
+  describe('sizing', () => {
+    it('gives the smallest CI runner parallelism too', () => {
+      // The dominant cost is vitest's cold start, which barely scales with cores — the registry
+      // takes ~744s on 12 cores and ~777s on 4. A core-proportional formula would hand a 4-vCPU
+      // runner jobs=1, i.e. no benefit exactly where the wall clock hurts most.
+      expect(planJobs({ ...clean, cores: 4 }).jobs).toBe(2);
+    });
+
+    it('caps the worker count', () => {
+      // Each worker starts a vitest that forks again; past 4 the workers fight each other.
+      expect(planJobs({ ...clean, cores: 64 }).jobs).toBe(4);
+    });
+
+    it('never spawns more workers than there are mutations', () => {
+      expect(planJobs({ cores: 12, mutationCount: 3 }).jobs).toBe(3);
+    });
+
+    it('stays sequential for a single mutation', () => {
+      // `--id=<one>` is the common local invocation; a worktree would be pure overhead.
+      expect(planJobs({ cores: 12, mutationCount: 1 }).jobs).toBe(1);
+    });
+  });
+
+  describe('explicit --jobs wins', () => {
+    it('honours a higher count than the default', () => {
+      expect(planJobs({ ...clean, cores: 4, explicit: 4 }).jobs).toBe(4);
+    });
+
+    it('honours --jobs=1 as the documented escape hatch', () => {
+      expect(planJobs({ ...clean, explicit: 1 }).jobs).toBe(1);
+    });
+
+    it('ignores a non-numeric or non-positive value rather than failing the run', () => {
+      // `--jobs=` / `--jobs=oops` come through as NaN; a mutation run must not die over a typo in
+      // a performance knob.
+      expect(planJobs({ ...clean, explicit: Number.NaN }).jobs).toBe(4);
+      expect(planJobs({ ...clean, explicit: 0 }).jobs).toBe(4);
+      expect(planJobs({ ...clean, explicit: -2 }).jobs).toBe(4);
+    });
+  });
+});


### PR DESCRIPTION
Release PR for **11.36.2**. Tooling-only — `src/` is untouched.

## Do I need to do anything?

**No.** `pnpm update @lenne.tech/nest-server@11.36.2` and you are done. No config, no API, no behaviour change.

## What changed

`check:mutations` — the gate that proves the regression tests are not vacuous — now runs several mutations at once.

**744s → 399s (1.87×)** at 4 jobs. All 49 verdicts were diffed against a sequential run and are identical; that diff is the acceptance test, not the stopwatch.

### Why it was slow (not where you would guess)

The specs behind all 29 e2e mutations add up to **~40 seconds**. The rest was vitest's cold start, paid once per mutation, 49 times. That work is largely single-threaded I/O and barely scales with cores — the registry measures **744s on a 12-core laptop and 777s on a 4-vCPU CI runner**. A bigger runner would have bought almost nothing.

### How the isolation works

A mutation writes into the source tree, so N cannot simply run at once. Each worker gets its own `git worktree`, with `node_modules` symlinked from the main checkout.

A worktree is at **HEAD**, so parallel mode tests committed code. When `src/` or `tests/` is dirty — or `--allow-dirty` is passed — the run prints why and falls back to sequential. A fast answer about the wrong source is worse than a slow answer about the right one.

The worker count floors at 2 rather than scaling from cores: a core-proportional formula hands a 4-vCPU runner `jobs=1`, i.e. no benefit exactly where it is needed.

## Also

`@vitest/ui` removed — no script passes `--ui`, no config imports it.

`check` green: 3461 tests, audit clean, build and server-start pass. `tests/unit/mutation-jobs-planning.spec.ts` pins the parallel/sequential decision including both dirty-tree refusals.