### PR TITLE
11.36.3 (retag): the regression gate was rubber-stamping in CI

### DIFF
--- a/.github/workflows/regression-evidence.yml
+++ b/.github/workflows/regression-evidence.yml
@@ -1,0 +1,76 @@
+# Runs the regression-evidence gate (`check:mutations`) ON DEMAND.
+#
+# WHY THIS EXISTS: the gate lived only in `publish.yml`, which triggers on `release: released`. So
+# the only way to observe it on a CI runner was to cut a release — and when it reported `0/51` while
+# publishing 11.36.3, investigating meant cutting another one. A gate you cannot run without
+# shipping is a gate you cannot debug.
+#
+# Deliberately NOT on push: it edits source and re-runs whole e2e suites (~10-18 min). It stays a
+# publish-path gate; this workflow only makes the same command reachable by hand.
+#
+# The setup mirrors publish.yml's steps up to the gate (which runs there BEFORE `build`, after
+# `prepublishOnly` = lint + tests). Lint and the suite are skipped here: they say nothing about the
+# gate, and the gate provisions its own databases.
+name: Regression evidence
+
+on:
+  workflow_dispatch:
+    inputs:
+      args:
+        description: 'Extra arguments, e.g. "--no-infra" or "--id=<mutation-id>" (empty = full registry)'
+        required: false
+        default: ''
+        type: string
+
+jobs:
+  mutations:
+    name: Regression evidence
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [ 24.x ]
+        mongodb-version: [ '7.0' ]
+    # Same container names and teardown contract as publish.yml / build.yml — a leftover container
+    # fails the NEXT job on a name conflict on a self-hosted runner.
+    env:
+      REDIS_CONTAINER: ci-redis
+      RUSTFS_CONTAINER: ci-rustfs
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v7
+
+      - name: Install pnpm
+        # No version input: the exact version is read from package.json's packageManager field.
+        uses: pnpm/action-setup@v6
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.12.1
+        with:
+          mongodb-version: ${{ matrix.mongodb-version }}
+
+      - name: Start test infrastructure (Redis + S3)
+        uses: ./.github/actions/test-infra
+        with:
+          redis-name: ${{ env.REDIS_CONTAINER }}
+          rustfs-name: ${{ env.RUSTFS_CONTAINER }}
+
+      - name: Install dependencies
+        run: pnpm install
+
+      # The dispatch input goes through the ENVIRONMENT, never interpolated into the shell line:
+      # `run: pnpm run check:mutations ${{ inputs.args }}` would let a dispatcher inject arbitrary
+      # commands into the runner. Unquoted on use, because the value is a list of flags.
+      - name: Regression evidence (mutation check)
+        env:
+          MUTATION_ARGS: ${{ inputs.args }}
+        run: pnpm run check:mutations -- $MUTATION_ARGS
+
+      - name: Remove test infrastructure
+        if: always()
+        run: docker rm -f "$REDIS_CONTAINER" "$RUSTFS_CONTAINER" 2>/dev/null || true

--- a/scripts/check-mutations.mjs
+++ b/scripts/check-mutations.mjs
@@ -360,6 +360,17 @@ export function selectMutations({ changed, mutations, noInfra: infraFree = false
 }
 
 /**
+ * Remove ANSI colour/style sequences from captured output.
+ *
+ * Anything that PARSES a spawned run's output must go through this: the same command is colourless
+ * on a pipe locally and colourised on a CI runner, so a regex tested locally can be reliably wrong
+ * in exactly the place where the answer matters.
+ */
+export function stripAnsi(text) {
+  return String(text ?? '').replace(/\u001b\[[0-9;]*m/g, '');
+}
+
+/**
  * Turn one vitest run into a verdict — pure, so the rule can be tested without running vitest.
  *
  * Three outcomes, and the third is the one that matters:
@@ -377,7 +388,16 @@ export function selectMutations({ changed, mutations, noInfra: infraFree = false
  *   only on a verdict that needs explaining — a passing one has nothing to explain.
  */
 export function classifyRun({ code, output }) {
-  const text = String(output ?? '');
+  // Strip ANSI first. vitest COLOURS its summary on a CI runner, so the raw line carries escape
+  // sequences between `Tests` and the number — and `\s+` matches whitespace only, never an escape
+  // sequence. Not hypothetical: it made every one of 51 mutations INCONCLUSIVE while the specs had
+  // gone red exactly as required.
+  //
+  // Worth knowing WHY this surfaced only now: the previous verdict was `failedCount ?? 'some'` with
+  // `ok: true` on any non-zero exit, so it never needed the count. The regex was already blind to
+  // colour — the gate simply accepted a crash, a timeout or a collection error as "went red". The
+  // strict count is the fix; this is what the fix depends on.
+  const text = stripAnsi(String(output ?? ''));
   const failedCount = text.match(/Tests\s+(\d+) failed/)?.[1];
   if (code === 0) {
     return {
@@ -414,7 +434,7 @@ export function classifyRun({ code, output }) {
  * Bounded deliberately: 51 mutations x a full vitest log would bury the summary that matters.
  */
 export function tailOf(output, lines = 25) {
-  const trimmed = String(output ?? '').trimEnd();
+  const trimmed = stripAnsi(String(output ?? '')).trimEnd();
   if (!trimmed) return '(no output captured)';
   const all = trimmed.split('\n');
   const tail = all.slice(-lines);

--- a/scripts/check-mutations.mjs
+++ b/scripts/check-mutations.mjs
@@ -373,12 +373,15 @@ export function selectMutations({ changed, mutations, noInfra: infraFree = false
  *   look like product failures. So require ACTUAL FAILING TESTS; anything else needs a human.
  *
  * @param {{ code: number, output: string }} run
- * @returns {{ label: string, note: string, ok: boolean }}
+ * @returns {{ evidence?: string, label: string, note: string, ok: boolean }} `evidence` is present
+ *   only on a verdict that needs explaining — a passing one has nothing to explain.
  */
 export function classifyRun({ code, output }) {
-  const failedCount = String(output ?? '').match(/Tests\s+(\d+) failed/)?.[1];
+  const text = String(output ?? '');
+  const failedCount = text.match(/Tests\s+(\d+) failed/)?.[1];
   if (code === 0) {
     return {
+      evidence: tailOf(text),
       label: 'VACUOUS: the specs passed with the defect restored',
       note: 'specs stayed GREEN with the defect restored — vacuous',
       ok: false,
@@ -386,7 +389,8 @@ export function classifyRun({ code, output }) {
   }
   if (!failedCount) {
     return {
-      label: 'INCONCLUSIVE: the run failed but reported no failing tests — crash, timeout or collection error',
+      evidence: tailOf(text),
+      label: `INCONCLUSIVE: the run exited ${code} but reported no failing tests — crash, timeout or collection error`,
       note: 'run exited non-zero without reporting failing tests — inconclusive, re-run this one alone',
       ok: false,
     };
@@ -396,6 +400,25 @@ export function classifyRun({ code, output }) {
     note: `${failedCount} test(s) failed, as required`,
     ok: true,
   };
+}
+
+/**
+ * The last few lines of a captured run, for a verdict that needs explaining.
+ *
+ * WHY THIS EXISTS: `INCONCLUSIVE` was added so a crashed or starved run could not be counted as
+ * evidence — correct, but it left the operator with a verdict and nothing to act on. That cost a
+ * release: the gate reported `0/51 mutations confirmed` on a CI runner, every one of them
+ * inconclusive, and the vitest output that would have said WHY had been captured into a variable
+ * and thrown away. A refusal has to carry its reason, or the next person is where I was.
+ *
+ * Bounded deliberately: 51 mutations x a full vitest log would bury the summary that matters.
+ */
+export function tailOf(output, lines = 25) {
+  const trimmed = String(output ?? '').trimEnd();
+  if (!trimmed) return '(no output captured)';
+  const all = trimmed.split('\n');
+  const tail = all.slice(-lines);
+  return (all.length > lines ? [`… ${all.length - lines} earlier line(s) omitted`, ...tail] : tail).join('\n');
 }
 
 /**
@@ -626,6 +649,10 @@ async function runOne(mutation, cwd, jobs, live) {
     const { code, output } = await runSpecs(mutation.specs, cwd, jobs);
     const verdict = classifyRun({ code, output });
     emit(`   ${verdict.label}\n`);
+    // A failing verdict without its reason is what made the 11.36.3 CI failure undiagnosable.
+    if (verdict.evidence) {
+      emit(`${verdict.evidence.replace(/^/gm, '   | ')}\n`);
+    }
     return { id: mutation.id, log, note: verdict.note, ok: verdict.ok };
   } finally {
     // Only restore what we actually wrote — see the race check above.

--- a/tests/unit/mutation-jobs-planning.spec.ts
+++ b/tests/unit/mutation-jobs-planning.spec.ts
@@ -13,7 +13,14 @@
  */
 import { describe, expect, it } from 'vitest';
 
-import { applyMutation, classifyRun, planJobs, resolveSinceRef, selectMutations } from '../../scripts/check-mutations.mjs';
+import {
+  applyMutation,
+  classifyRun,
+  planJobs,
+  resolveSinceRef,
+  selectMutations,
+  tailOf,
+} from '../../scripts/check-mutations.mjs';
 
 const clean = { cores: 12, mutationCount: 49 };
 
@@ -227,6 +234,52 @@ describe('classifyRun', () => {
   it('does not throw on empty or missing output', () => {
     expect(classifyRun({ code: 1, output: '' }).ok).toBe(false);
     expect(classifyRun({ code: 1, output: undefined }).ok).toBe(false);
+  });
+
+  /**
+   * A refusal has to carry its reason. `0/51 mutations confirmed` with every verdict INCONCLUSIVE
+   * and no captured output is what made the 11.36.3 CI failure impossible to diagnose without
+   * cutting another release.
+   */
+  it('attaches the captured output to a verdict that needs explaining', () => {
+    const inconclusive = classifyRun({ code: 1, output: 'Error: socket hang up' });
+    const vacuous = classifyRun({ code: 0, output: 'Tests  20 passed (20)' });
+
+    expect(inconclusive.evidence).toContain('socket hang up');
+    expect(vacuous.evidence).toContain('20 passed');
+  });
+
+  it('names the exit code, so a crash and a starved run are distinguishable', () => {
+    expect(classifyRun({ code: 137, output: 'killed' }).label).toContain('137');
+  });
+
+  it('attaches NO output to a passing verdict — there is nothing to explain', () => {
+    expect(classifyRun({ code: 1, output: 'Tests  2 failed | 18 passed (20)' }).evidence).toBeUndefined();
+  });
+});
+
+describe('tailOf', () => {
+  it('keeps the last lines, where a failure summary lives', () => {
+    const out = tailOf(Array.from({ length: 100 }, (_, i) => `line ${i}`).join('\n'), 3);
+
+    expect(out).toContain('line 99');
+    expect(out).not.toContain('line 50');
+  });
+
+  it('says how much it dropped rather than truncating silently', () => {
+    const out = tailOf(Array.from({ length: 100 }, (_, i) => `line ${i}`).join('\n'), 3);
+
+    expect(out).toContain('97 earlier line(s) omitted');
+  });
+
+  it('returns everything when it fits, with no omission notice', () => {
+    expect(tailOf('a\nb', 25)).toBe('a\nb');
+  });
+
+  it('says so explicitly when nothing was captured', () => {
+    // Distinguishes "the run printed nothing" from "we forgot to capture it".
+    expect(tailOf('')).toBe('(no output captured)');
+    expect(tailOf(undefined)).toBe('(no output captured)');
   });
 });
 

--- a/tests/unit/mutation-jobs-planning.spec.ts
+++ b/tests/unit/mutation-jobs-planning.spec.ts
@@ -19,6 +19,7 @@ import {
   planJobs,
   resolveSinceRef,
   selectMutations,
+  stripAnsi,
   tailOf,
 } from '../../scripts/check-mutations.mjs';
 
@@ -255,6 +256,59 @@ describe('classifyRun', () => {
 
   it('attaches NO output to a passing verdict — there is nothing to explain', () => {
     expect(classifyRun({ code: 1, output: 'Tests  2 failed | 18 passed (20)' }).evidence).toBeUndefined();
+  });
+});
+
+/**
+ * The defect that cost the 11.36.3 publish: vitest colours its summary on a CI runner, so the raw
+ * line reads `Tests <esc>[22m <esc>[1m<esc>[31m3 failed`. `\s+` matches whitespace, never an escape
+ * sequence — so the count did not parse, and all 51 mutations reported INCONCLUSIVE while their
+ * specs had gone red exactly as required.
+ *
+ * Locally the same command is COLOURLESS (stdout is a pipe), which is why nothing caught it: the
+ * one environment where the parse mattered was the one environment never exercised.
+ */
+describe('classifyRun on a colourised CI runner', () => {
+  const ESC = String.fromCharCode(27);
+  const colour = (code: string, text: string) => `${ESC}[${code}m${text}${ESC}[39m`;
+  const CI_SUMMARY =
+    `${ESC}[2m      Tests ${ESC}[22m ${colour('31', '3 failed')}${ESC}[2m | ${ESC}[22m${colour('32', '19 passed')}${ESC}[90m (22)${ESC}[39m`;
+
+  it('reads the failure count through the colour codes', () => {
+    const verdict = classifyRun({ code: 1, output: CI_SUMMARY });
+
+    expect(verdict.ok, 'a coloured "3 failed" is still three failures').toBe(true);
+    expect(verdict.note).toContain('3 test(s) failed');
+  });
+
+  it('still calls a coloured crash INCONCLUSIVE', () => {
+    // The paired refusal: stripping colour must not make everything parse as a pass.
+    const verdict = classifyRun({ code: 1, output: colour('31', 'Error: socket hang up') });
+
+    expect(verdict.ok).toBe(false);
+    expect(verdict.label).toContain('INCONCLUSIVE');
+  });
+
+  it('strips colour from the evidence, so a human can read it', () => {
+    const verdict = classifyRun({ code: 1, output: colour('31', 'Error: boom') });
+
+    expect(verdict.evidence).toContain('Error: boom');
+    expect(verdict.evidence).not.toContain(ESC);
+  });
+});
+
+describe('stripAnsi', () => {
+  const ESC = String.fromCharCode(27);
+
+  it('removes colour sequences and keeps the text', () => {
+    expect(stripAnsi(`${ESC}[31mred${ESC}[39m`)).toBe('red');
+    expect(stripAnsi(`${ESC}[1m${ESC}[2mbold-dim${ESC}[22m`)).toBe('bold-dim');
+  });
+
+  it('leaves uncoloured text untouched and tolerates nothing at all', () => {
+    expect(stripAnsi('plain')).toBe('plain');
+    expect(stripAnsi('')).toBe('');
+    expect(stripAnsi(undefined)).toBe('');
   });
 });
 


### PR DESCRIPTION
Follow-up to the failed 11.36.3 publish, which reported `0/51 mutations confirmed`.

## Root cause

vitest **colourises** its summary on a CI runner, so the line carries escape sequences between `Tests` and the number. `/Tests\s+(\d+) failed/` matches whitespace, never an escape sequence — so the count did not parse and every mutation was reported `INCONCLUSIVE`, while the specs had gone red exactly as required.

Locally the same command is colourless, because stdout is a pipe. The one environment where the parse mattered was the one never exercised.

## The part that matters beyond this release

The regex was **already** blind to colour. It surfaced only now because the previous verdict was `failedCount ?? 'some'` with `ok: true` on any non-zero exit — it never needed the count. So on the publish path the gate had been accepting a crash, a timeout, a collection error or resource starvation as "went red": precisely what `INCONCLUSIVE` was introduced to refuse.

The strict count (added in 11.36.3) is the fix. Stripping colour is what that fix depends on. Together they turn the CI gate from a rubber stamp into an actual check.

## Changes

| Change | Effect |
|---|---|
| `stripAnsi()` before parsing | the count is read through colour; `tailOf()` yields readable evidence |
| `evidence` on the verdict | an `INCONCLUSIVE` now says **why** — the last 25 lines of the run |
| exit code in the label | a crash and a starved run are distinguishable |
| `Regression evidence` workflow | the gate is runnable via `workflow_dispatch`, not only by cutting a release |

The last one is why this was diagnosable at all: the gate previously lived only in `publish.yml` (`release: released`), so observing it cost a release and diagnosing it cost another. The dispatch input is passed through the environment, never interpolated into the shell line.

## Verification

Run on a real CI runner via the new workflow:

- before the fix: `0/51`
- unit subset after the fix: `21/21`
- **full registry after the fix: `51/51`**

Local `check` green (3537 tests, lint clean, audit 0/0/0/0). 5 new tests reproduce the CI condition with real escape sequences, including the paired refusal — a *coloured* crash must still be `INCONCLUSIVE`, or stripping colour would simply wave everything through.