### PR TITLE
11.37.0: better-auth 1.7 — required peer dependency and account.issuer backfill

### DIFF
--- a/.claude/rules/better-auth.md
+++ b/.claude/rules/better-auth.md
@@ -425,6 +425,37 @@ Both are needed. `processCookies()` returns early once a session token is presen
 `processAuthResult()` — and every unit test of it — is **unreachable** from the path the fix
 repairs. Only the second row observes the defect the way a browser would.
 
+## 8. Do NOT add `issuer` to this package's own `account` reads
+
+From better-auth 1.7 an account is keyed by `(issuer, accountId)`, and `CoreBetterAuthService`
+backfills the field on boot for rows written by 1.6. It is tempting to make this package's own
+reads of the `account` collection match — they filter on `providerId` alone:
+
+| Method | File |
+|---|---|
+| `syncPasswordChangeToIam()` | `core-better-auth-user.mapper.ts` |
+| `migrateAccountToIam()` (the fast-path existence check) | `core-better-auth-user.mapper.ts` |
+| `getMigrationStatus()` | `core-better-auth-user.mapper.ts` |
+
+**Adding `issuer` to those filters looks like consistency and is a regression.** They must keep
+working on rows the backfill has not reached:
+
+- `getMigrationStatus()` would report **zero** migrated users on a database that has not been
+  backfilled yet — the exact moment an operator consults it.
+- `syncPasswordChangeToIam()` would stop finding the account it is meant to update, silently
+  desynchronising the password it was called to sync.
+
+This matters most when the backfill has **failed**: it is deliberately non-fatal, so the server
+boots and these reads are the only thing still working on un-backfilled rows. A "unified" filter
+breaks precisely in the situation it would be needed.
+
+Only better-auth's own sign-in path requires the issuer, and that code is better-auth's, not ours.
+**Writes are the opposite rule** — every write to the collection MUST set the issuer, derived via
+`createLocalAccountIssuer(...)` and never hand-written.
+
+Covered by mutations `account-issuer-backfill-missing`, `account-issuer-missing-on-migrate` and
+`account-issuer-missing-on-link-account` in `tests/regression-mutations.json`.
+
 ## Summary
 
 | Principle | Requirement |
@@ -436,3 +467,4 @@ repairs. Only the second row observes the defect the way a browser would.
 | Guards | Maintain both RolesGuard and BetterAuthRolesGuard in sync |
 | DI Tokens | Import-free leaf file only — never in `*.module.ts` / `*.service.ts` (§6) |
 | Session cookie | Always the opaque session token — never the body JWT (§7) |
+| `account` reads | Filter on `providerId` alone; never add `issuer` to a READ. Every WRITE must set it (§8) |

--- a/.claude/rules/framework-compatibility.md
+++ b/.claude/rules/framework-compatibility.md
@@ -75,5 +75,6 @@ This framework compatibility strategy spans multiple repositories:
 | `nuxt-extensions` | Same pattern: `CLAUDE.md` shipped with npm package |
 | `nuxt-base-starter` | `CLAUDE.md` points Claude to nuxt-extensions source |
 | `claude-code/plugins/lt-dev` | Hooks detect frameworks, Skills reference source paths |
+| `cli` (lt CLI) | Holds `src/config/vendor-runtime-deps.json`. Every change to THIS repo's dependency **shape** — a package moved between `dependencies`, `devDependencies` and `peerDependencies` — must be mirrored there in the same release, or vendor-mode consumers install a core whose imports they do not declare |
 
 The full strategy document is maintained in the claude-code plugin repository.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -284,7 +284,7 @@ when the registry, a vitest config or a setup file changed, since those can move
 **Why the gate does not cache per-mutation verdicts instead.** It runs ONCE PER RELEASE, not per
 commit, so selective re-running would save ~10 minutes a release. The price is a cache that has to
 model each spec's full dependency closure correctly, and getting that wrong produces a stale PASS
-for a test that has since gone vacuous — exactly what the gate is there to prevent. Bad trade at 53
+for a test that has since gone vacuous — exactly what the gate is there to prevent. Bad trade at 56
 mutations. Worth revisiting around 100, where the full run approaches half an hour.
 
 Not part of `pnpm run check` — it edits source and re-runs whole e2e suites. It belongs in review
@@ -324,9 +324,9 @@ exactly the environment where the answer matters.
 
 ### The cost is vitest's cold start, not the tests
 
-Worth knowing before optimising the wrong thing: the specs behind all 31 e2e mutations add up to
+Worth knowing before optimising the wrong thing: the specs behind all 34 e2e mutations add up to
 **~40 seconds**. The step takes ~740s. The remaining ~700s is paying vitest's startup — process
-spawn, transform, module graph, mongod connect, DB create and drop — once per mutation, 53 times.
+spawn, transform, module graph, mongod connect, DB create and drop — once per mutation, 56 times.
 That work is largely single-threaded I/O and barely scales with cores: the full registry measures
 **744s on a 12-core laptop and 777s on a 4-vCPU CI runner**.
 

--- a/.claude/rules/versioning.md
+++ b/.claude/rules/versioning.md
@@ -16,6 +16,12 @@
 
 ## Important Rules
 
+0. **Never promote a breaking change to a MAJOR.** The MAJOR digit is not ours to spend — it
+   states which NestJS major this package targets, and moves only when NestJS does. A removed
+   API, a changed signature, a dependency turned into a required peer: all of them are MINOR
+   releases here. This is the rule most likely to be broken by someone applying ordinary semver
+   reflexes, and the moment it happens is exactly when the change feels big enough to "deserve"
+   a major.
 1. **Document breaking changes** clearly in commit messages when incrementing MINOR version
 2. **Update nest-server-starter** with migration instructions for breaking changes
 3. **Consider downstream impact** - this package is used by multiple projects

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,11 +82,21 @@ compatible with either downstream layout:
   reads it at sync time — keep the migration guides readable outside
   of an npm-install context (no `node_modules/…` path references).
 
-- **`package.json` devDeps** used at runtime by framework code (e.g.
-  `find-file-up` in the config loader) must be listed in the CLI's
-  `src/config/vendor-runtime-deps.json` as a runtime helper, otherwise
-  vendor consumers miss them at install time. Prefer putting
-  runtime-used packages in `dependencies` directly, not `devDependencies`.
+- **`package.json` devDeps AND peerDeps** used at runtime by framework code
+  must be listed in the CLI's `src/config/vendor-runtime-deps.json` as a
+  runtime helper, otherwise vendor consumers miss them at install time.
+  The vendoring step copies `dependencies` only — it never reads
+  `peerDependencies` — so a package in either of the other two sections is
+  invisible to it. Both cases are live today: `find-file-up` (a devDep the
+  config loader imports) and `better-auth` / `@better-auth/passkey` /
+  `@better-auth/core` (required peers since 11.37.0).
+  **A peer listed there must ALSO stay in `devDependencies`**: the CLI reads
+  the version from the upstream devDeps, so removing it as "redundant with
+  the peer range" silently leaves vendor consumers without the package, with
+  nothing failing in this repo. Prefer putting runtime-used packages in
+  `dependencies` directly — the exception is a package whose version the
+  CONSUMER must own (better-auth, because a fullstack project's api and app
+  must not resolve different versions of it).
 
 - **Vendor-mode projects never run `pnpm update @lenne.tech/nest-server`.**
   They use `/lt-dev:backend:update-nest-server-core` instead, which
@@ -207,6 +217,13 @@ See `.claude/rules/role-system.md` for complete documentation.
 ### Versioning
 
 `MAJOR.MINOR.PATCH` where MAJOR = NestJS version, MINOR = breaking changes, PATCH = non-breaking.
+
+**A breaking change gets a MINOR here. Never reach for a MAJOR.** The MAJOR digit means "targets
+NestJS N" and moves only when NestJS does — so removed APIs, changed signatures, a dependency
+turned into a required peer all ship as a minor. Semver habits say otherwise; they are wrong in
+this repo, and the mistake is easy to make precisely while writing a genuinely breaking release.
+The migration guide carries that weight instead: state up front that the minor contains breaking
+changes, so nobody reads the version number as a promise it does not make.
 
 See `.claude/rules/versioning.md` for release process.
 

--- a/FRAMEWORK-API.md
+++ b/FRAMEWORK-API.md
@@ -1,6 +1,6 @@
 # @lenne.tech/nest-server — Framework API Reference
 
-> Auto-generated from source code on 2026-08-23 (v11.36.5)
+> Auto-generated from source code on 2026-08-23 (v11.37.0)
 > File: `FRAMEWORK-API.md` — compact, machine-readable API surface for Claude Code
 
 ## CoreModule.forRoot()

--- a/migration-guides/11.36.x-to-11.37.0.md
+++ b/migration-guides/11.36.x-to-11.37.0.md
@@ -1,0 +1,344 @@
+# Migration Guide: 11.36.x → 11.37.0
+
+> **This MINOR carries breaking changes.** That is not a slip. In this package the MAJOR digit
+> tracks the NestJS major it targets — 11.x is NestJS 11 — so it moves only when NestJS does.
+> Breaking changes of our own ship in a minor, which is why every one of them is spelled out
+> below. Read §1 before you upgrade — and do not wait for `pnpm install` to tell you: on pnpm's
+> defaults it will quietly install the new peers for you, at a version you never pinned.
+
+## Overview
+
+| Category | Details |
+|----------|---------|
+| **Breaking Changes** | **`better-auth` is no longer a dependency of this package — it is a peer dependency you must declare yourself** (§1). It moves to **1.7.x** and cannot be held back (§2). `@better-auth/core` joins the contract as a third required peer (§1) |
+| **New Features** | `account.issuer` is backfilled automatically on the first boot after the upgrade, so existing password users keep signing in (§3) |
+| **Bugfixes** | Legacy→IAM account migration wrote an account better-auth 1.7 could not find, which turned the very sign-in that triggered the migration into a 401 (§3) |
+| **Migration Effort** | **Every project: one package.json change (§1) and one deployment note (§3).** Add ~15 minutes if you use social or SSO logins (§4), and read §5 before running two nest-server versions against one database |
+
+---
+
+## Quick Migration
+
+```bash
+pnpm add better-auth@1.7.1 @better-auth/passkey@1.7.1 @better-auth/core@1.7.1
+pnpm add @lenne.tech/nest-server@11.37.0
+pnpm run build
+```
+
+Then read §3 — it concerns your **data**, not your code, and no build will tell you about it.
+
+---
+
+## 1. `better-auth` is now a peer dependency
+
+**Were you affected?** Every project — and the failure mode depends on your package manager,
+which is why you cannot rely on the install to flag it.
+
+| Setting | What `pnpm install` does |
+|---|---|
+| `autoInstallPeers: true` (**pnpm's default**) | installs the peers **silently**, resolving anywhere inside `>=1.7.1 <1.8.0` |
+| `autoInstallPeers: false` | fails with a missing-peer error |
+| `strictPeerDependencies: true` | fails on a version outside the range |
+
+Most projects are on the default, so a green install proves nothing: you end up with an
+unpinned better-auth that can drift on the next install — exactly the split this section exists
+to prevent. Declare all three yourself, pinned, and verify with:
+
+```bash
+pnpm why better-auth       # must show YOUR declaration, not just a peer-resolved copy
+```
+
+### What changed
+
+Up to 11.36.x, `package.json` carried better-auth as an exactly pinned **dependency**:
+
+```jsonc
+"dependencies": {
+  "better-auth": "1.6.26",
+  "@better-auth/passkey": "1.6.26"
+}
+```
+
+From 11.37.0 they are **peer dependencies**, and `@better-auth/core` joins them:
+
+```jsonc
+"peerDependencies": {
+  "better-auth": ">=1.7.0 <1.8.0",
+  "@better-auth/passkey": ">=1.7.0 <1.8.0",
+  "@better-auth/core": ">=1.7.0 <1.8.0"
+}
+```
+
+All three are **non-optional**. That is deliberate and differs from the five peers this package
+already had (`ioredis`, `bullmq`, `@aws-sdk/*`, `@tus/s3-store`), which are `optional: true` and
+lazily imported. better-auth is imported statically at the top of
+`src/core/modules/better-auth/better-auth.config.ts` — if it is missing, the server does not
+degrade, it fails to boot.
+
+Add them to your own `package.json`, exactly pinned:
+
+```jsonc
+"dependencies": {
+  "better-auth": "1.7.1",
+  "@better-auth/passkey": "1.7.1",
+  "@better-auth/core": "1.7.1"
+}
+```
+
+### Why
+
+An exact pin inside a library makes the library the owner of that version. A project could not
+raise better-auth without overriding this package, and in a fullstack setup that is fatal: the
+frontend (`@lenne.tech/nuxt-extensions`) has always declared better-auth as a **peer**, so the app
+could move to 1.7 while the api was pinned to 1.6.26 — a client and a server speaking different
+versions of the same protocol. See §2 for what that actually broke.
+
+The version now belongs to the project, which is the only place that can keep client and server in
+step. The narrow range is not overcaution: better-auth breaks in **minor** releases (1.7 removed
+the `./plugins/oidc-provider` and `./plugins/mcp/client` subpath exports and changed the 2FA
+response shape), so `^1.7.0` would invite the same split at 1.8.
+
+### Vendor mode
+
+Vendor-mode projects already carry better-auth in their own `package.json` — that is what vendoring
+means — so the *mechanism* does not change. The work does:
+
+- bump `better-auth` and `@better-auth/passkey` from `1.6.26` to `1.7.1`, and
+- **add `@better-auth/core`**, which has never been in your manifest.
+
+`/lt-dev:backend:update-nest-server-core` rewrites `src/core/**` and does **not** touch
+`package.json` — these three lines are yours to change. For a NEW vendor-mode project, the `lt`
+CLI must be new enough to carry all three in `src/config/vendor-runtime-deps.json`; an older CLI
+vendors a core that imports packages the generated manifest never declares.
+
+---
+
+## 2. better-auth moves to 1.7.x
+
+**Were you affected?** Every project, and **fullstack projects most of all**.
+
+`>=1.7.0 <1.8.0` has no 1.6 in it. This is not a version you can defer.
+
+### What this fixes
+
+better-auth 1.7 gives `twoFactor.enable` a discriminated result carrying
+`method: "otp" | "totp"`. A 1.7 client narrows on that discriminant before reading `totpURI` and
+`backupCodes`. A 1.6.26 server never sends the field, so the narrowing fails and **every 2FA
+activation is rejected** — with a generic error, against a server that logs nothing unusual.
+
+If your app is on `@lenne.tech/nuxt-extensions` with better-auth 1.7 and your api was still on
+11.36.x, that is what your users were hitting.
+
+### What it costs
+
+Two API changes in better-auth 1.7 reach code you may have written yourself:
+
+- `context.internalAdapter.createUser(user)` now takes a second argument:
+  `createUser(user, { method })`, where `method` is the provisioning source
+  (`'email-password' | 'admin' | 'oauth' | …`).
+- `context.internalAdapter.linkAccount()` requires `issuer` — see §3.
+
+Both are compile errors, so `pnpm run build` finds them. Anything writing to the `account`
+collection **directly** will not be caught by the compiler — see §3.
+
+---
+
+## 3. `account.issuer`: the part no build will tell you about
+
+**Were you affected?** Every project with existing users. This is a **data** change.
+
+### What changed
+
+Up to 1.6 a credential account was identified by `providerId` + `userId`. From 1.7 an account is
+keyed by **(issuer, accountId)**, and the sign-in route filters on it verbatim:
+
+```js
+account.providerId === 'credential' && account.issuer === credentialIssuer && account.accountId === user.id
+```
+
+Every account row written by better-auth 1.6 has **no `issuer` field at all**. `undefined` never
+equals `'local:credential'`, so after the upgrade better-auth cannot find those accounts: **every
+existing password user is locked out**, with a 401 that says nothing about why.
+
+### What this package does about it
+
+On the first boot after the upgrade, `CoreBetterAuthService.onModuleInit()` backfills the field:
+
+```js
+db.collection('account').updateMany(
+  { issuer: { $exists: false }, providerId: 'credential' },
+  { $set: { issuer: createLocalAccountIssuer('credential') } },
+)
+```
+
+It is idempotent — the filter only matches rows still missing the field — and it logs how many rows
+it touched. If it fails, it logs an **error** and the server still starts, because a server that
+boots with a loud error beats one that will not boot at all. Check your logs for
+`Could not backfill account.issuer` after the first deployment.
+
+Credential accounts only. See §4 for why.
+
+### If you write to the `account` collection yourself
+
+Any code that inserts an account row directly through the Mongo driver bypasses better-auth's types
+and therefore the compiler. It must now set the issuer:
+
+```diff
+  await accountsCollection.insertOne({
+    accountId: userIdHex,
++   issuer: createLocalAccountIssuer('credential'),
+    password: passwordHash,
+    providerId: 'credential',
+    userId: userMongoId,
+  });
+```
+
+```ts
+import { createLocalAccountIssuer } from '@better-auth/core/db';
+```
+
+**Derive it, never hand-write `'local:credential'`.** The format is better-auth's to change, and a
+literal copy would keep compiling while silently no longer matching the accounts better-auth writes
+itself.
+
+This bug was live in this package: `CoreBetterAuthUserMapper.migrateAccountToIam()` wrote a
+credential account without the issuer, so a legacy user migrating to IAM got a 401 on the very
+sign-in that triggered the migration. It is fixed in 11.37.0, and 12 e2e tests that were red on
+better-auth 1.7 pin it.
+
+---
+
+## 4. Social and SSO logins are NOT backfilled
+
+**Were you affected?** Only projects using OAuth or SSO providers — but for those this is a
+**pre-upgrade** step, not a post-upgrade cleanup. See the numbered consequences below.
+
+The backfill deliberately stops at credential accounts. `local:credential` is a pure function of
+the provider id and therefore derivable. An OAuth account's issuer is not: it is either the
+provider's **real OIDC issuer** or the synthetic `local:oauth:<providerId>` fallback, decided per
+provider and overridable through the provider config.
+
+Guessing there would not fail loudly. It would write a key that looks valid, and produce a **second
+account** for the same user on the next social sign-in.
+
+So those rows are counted and reported instead. If your logs say
+
+```
+At least one non-credential account has no "issuer"
+```
+
+then act **before** the first social sign-in after the upgrade. Such a sign-in does **not** simply
+fail, which is the part that makes this urgent rather than merely broken:
+
+1. better-auth cannot match the row by `(issuer, accountId)`, so it falls back to matching the
+   user by the **provider-asserted email** and implicitly links a **second** account row. The
+   identity is now established from an email rather than from the provider key — a weaker binding.
+2. If the provider-side email has changed since the row was written, no user matches and
+   better-auth creates a **new user**. The original account is orphaned with its data.
+3. The orphaned row keeps its `accessToken` / `refreshToken`. Unlinking removes the *new* row, so
+   those provider credentials survive every unlink and every "revoke access" action.
+
+For a provider using the synthetic fallback:
+
+```js
+db.collection('account').updateMany(
+  { issuer: { $exists: false }, providerId: 'google' },
+  { $set: { issuer: 'local:oauth:google' } },
+)
+```
+
+For a provider with a real OIDC issuer, use that issuer verbatim. Confirm which of the two applies
+by reading a row better-auth wrote itself after the upgrade.
+
+---
+
+## 5. Deploying: do not run 11.36.x and 11.37.x against one database
+
+The backfill is safe to run repeatedly and safe to run while 11.37.x instances serve traffic. It is
+**not** safe to leave an 11.36.x instance running against the same database afterwards: 11.x keeps
+writing credential accounts without an issuer, and those rows are invisible to 11.37.x until the next
+restart backfills them.
+
+For a rolling deployment, either complete the rollout before relying on new sign-ups, or restart
+one 11.37.x instance after the last 11.36.x instance is gone.
+
+**Rollback** is safe in the other direction: 1.6 ignores the extra `issuer` field, so a backfilled
+database still works with 11.36.x.
+
+---
+
+## 6. Compatibility Notes
+
+Patterns this release does and does not disturb. All of these are override points projects
+legitimately use.
+
+| Pattern | Status | Notes |
+|---|---|---|
+| Subclassing `CoreBetterAuthService` | Compatible | `backfillAccountIssuers()` and `ensureIndices()` are `protected` — override either to change behaviour |
+| **Overriding `onModuleInit()`** | **Action required** | It now runs two steps. An override that does not call `super.onModuleInit()` silently skips the backfill, and your existing password users stay locked out with no error anywhere. Call `super`, or call both `protected` methods yourself |
+| Subclassing `CoreSystemSetupService` | Compatible | See §7 if you override `createInitialAdmin()` — it now passes a provisioning source |
+| Subclassing `CoreBetterAuthUserMapper` | Compatible | An override of `migrateAccountToIam()` that builds the account document itself MUST add `issuer: createLocalAccountIssuer('credential')`, or the migrated user gets a 401 on the sign-in that triggered the migration |
+| Custom `account` collection name / `issuer` field | Compatible | The backfill resolves both from the running better-auth instance and warns when they differ from the defaults |
+| `betterAuth.options.user.validateUserInfo` | **Action required** | See §7 |
+| Reading the `account` collection directly | Compatible | Framework reads deliberately filter on `providerId` alone, so they keep working on un-backfilled rows. Do not add `issuer` to such a filter |
+
+---
+
+## 7. `validateUserInfo` and the initial admin
+
+**Were you affected?** Only projects that configure `betterAuth.options.user.validateUserInfo`.
+
+better-auth 1.7 requires a *provisioning source* on `internalAdapter.createUser()`, and
+`CoreSystemSetupService` now passes `{ method: 'admin' }`. Two consequences:
+
+1. Your hook still runs — the source does not bypass it. It receives
+   `{ method: 'admin', action: 'create-user' }`, so a domain allowlist or invite-code gate can
+   branch on `method` and let the first-admin provisioning through.
+2. **When the hook is configured, initial-admin setup fails.** better-auth additionally calls
+   `getCurrentAuthContext()`, which throws outside an endpoint context. System setup runs from
+   `OnApplicationBootstrap` or a plain controller — never inside better-auth's request pipeline —
+   so the call ends in `FORBIDDEN / validation_context_missing` and no admin is created.
+
+If you use `validateUserInfo`, provision the first administrator another way: create it through a
+request-scoped IAM route, or seed it before enabling the hook.
+
+---
+
+## 8. Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| **Every password user gets 401 after the upgrade.** Correct password, no useful log line | Their `account` rows predate better-auth 1.7 and carry no `issuer` | The backfill runs on the first boot. Check the log for `Backfilled account.issuer on N credential account(s)`. If absent, see the next two rows |
+| No backfill log at all, and users still cannot sign in | The backfill did not run: better-auth disabled, no DB connection, or an `onModuleInit()` override without `super` (§6) | Check `betterAuth.enabled`, then your override |
+| `Backfilled N/M credential accounts. X user(s) CANNOT sign in` | The bulk write hit a duplicate `(issuer, accountId)` pair, usually from an earlier partial migration | Find them: `db.account.aggregate([{$group:{_id:{i:'$issuer',a:'$accountId'},n:{$sum:1}}},{$match:{n:{$gt:1}}}])`, resolve the duplicates, restart |
+| `Backfilling the account issuer against a customised schema` | You renamed the account model or the issuer field | Expected. Verify the names match what better-auth writes |
+| `Could not backfill the account issuer: …` | The database rejected the operation | Boot is not blocked, but affected users cannot sign in. Fix the cause and restart — the backfill retries until it completes |
+| Social login creates a second account, or a brand-new empty user | An OAuth row without an issuer (§4) | Set the issuer per provider. The already-created duplicate must be merged manually |
+| Setup fails with `FORBIDDEN / validation_context_missing` | `validateUserInfo` is configured (§7) | Provision the first admin through a request-scoped path |
+| `pnpm install` succeeded but versions drift later | pnpm auto-installed the peers (§1) | Declare all three explicitly and pin them; verify with `pnpm why better-auth` |
+
+---
+
+## Module Documentation
+
+| Document | Relevance |
+|---|---|
+| [`src/core/modules/better-auth/README.md`](../src/core/modules/better-auth/README.md) | Module overview, the boot-time backfill, troubleshooting |
+| [`src/core/modules/better-auth/INTEGRATION-CHECKLIST.md`](../src/core/modules/better-auth/INTEGRATION-CHECKLIST.md) | Integration steps — **step 0 (installing the three peers) is new in 11.37.0** |
+| [`src/core/modules/better-auth/CUSTOMIZATION.md`](../src/core/modules/better-auth/CUSTOMIZATION.md) | Registration patterns and override points |
+| [`src/core/modules/system-setup/README.md`](../src/core/modules/system-setup/README.md) | Initial-admin provisioning (§7) |
+| [`.claude/rules/better-auth.md`](../.claude/rules/better-auth.md) | Development rules for the module |
+
+---
+
+## Checklist
+
+- [ ] `better-auth`, `@better-auth/passkey`, `@better-auth/core` declared in your own `package.json`, pinned to the same version (§1)
+- [ ] `pnpm run build` green — it finds the `createUser` and `linkAccount` signature changes (§2)
+- [ ] Every direct write to the `account` collection sets `issuer` via `createLocalAccountIssuer` (§3)
+- [ ] First boot after deployment checked for `Backfilled account.issuer` and for `Could not backfill` (§3)
+- [ ] Social/SSO projects: log checked for un-backfilled accounts, issuer set per provider (§4)
+- [ ] Fullstack projects: api and app on the **same** better-auth version (§1)
+- [ ] Rollout does not leave 11.36.x and 11.37.x on one database (§5)
+- [ ] `onModuleInit()` overrides call `super.onModuleInit()` (§6)
+- [ ] Projects using `validateUserInfo`: first-admin provisioning path checked (§7)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lenne.tech/nest-server",
-  "version": "11.36.5",
+  "version": "11.37.0",
   "description": "Modern, fast, powerful Node.js web framework in TypeScript based on Nest with a GraphQL API and a connection to MongoDB (or other databases).",
   "keywords": [
     "node",
@@ -83,14 +83,13 @@
     "url": "https://github.com/lenneTech/nest-server/issues"
   },
   "engines": {
-    "node": ">= 22",
+    "node": ">= 22.12",
     "pnpm": "^11.0.0"
   },
   "packageManager": "pnpm@11.13.1+sha512.b2fc7683b8a6525414e7d13e1ba28caaddde96bf66ec540bfaeb7e702b81f3e0be4d1f295edf7f9fe0396740a8dce4509c582ddf79891f4543fea32d37645f25",
   "dependencies": {
     "@apollo/server": "5.5.1",
     "@as-integrations/express5": "1.1.2",
-    "@better-auth/passkey": "1.6.26",
     "@getbrevo/brevo": "6.0.3",
     "@modelcontextprotocol/sdk": "1.30.0",
     "@nestjs/apollo": "13.4.5",
@@ -108,7 +107,6 @@
     "@tus/server": "2.4.4",
     "@types/supertest": "7.2.1",
     "bcrypt": "6.0.0",
-    "better-auth": "1.6.26",
     "class-transformer": "0.5.1",
     "class-validator": "0.15.1",
     "compression": "1.8.1",
@@ -144,7 +142,10 @@
   "peerDependencies": {
     "@aws-sdk/client-s3": ">=3.1045.0 <4",
     "@aws-sdk/s3-request-presigner": ">=3.1045.0 <4",
+    "@better-auth/core": ">=1.7.1 <1.8.0",
+    "@better-auth/passkey": ">=1.7.1 <1.8.0",
     "@tus/s3-store": ">=2.0.5 <3",
+    "better-auth": ">=1.7.1 <1.8.0",
     "bullmq": ">=5.16.0 <7",
     "ioredis": ">=5.0.0 <7"
   },
@@ -155,8 +156,17 @@
     "@aws-sdk/s3-request-presigner": {
       "optional": true
     },
+    "@better-auth/core": {
+      "optional": false
+    },
+    "@better-auth/passkey": {
+      "optional": false
+    },
     "@tus/s3-store": {
       "optional": true
+    },
+    "better-auth": {
+      "optional": false
     },
     "bullmq": {
       "optional": true
@@ -168,6 +178,8 @@
   "devDependencies": {
     "@aws-sdk/client-s3": "3.1115.0",
     "@aws-sdk/s3-request-presigner": "3.1115.0",
+    "@better-auth/core": "1.7.1",
+    "@better-auth/passkey": "1.7.1",
     "@compodoc/compodoc": "2.0.0",
     "@nestjs/cli": "11.0.24",
     "@nestjs/schematics": "11.1.0",
@@ -186,6 +198,7 @@
     "@types/passport": "1.0.17",
     "@vitest/coverage-v8": "4.1.11",
     "ansi-colors": "4.1.3",
+    "better-auth": "1.7.1",
     "bullmq": "6.2.0",
     "find-file-up": "2.0.1",
     "husky": "9.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,9 +31,6 @@ importers:
       '@as-integrations/express5':
         specifier: 1.1.2
         version: 1.1.2(@apollo/server@5.5.1(graphql@16.14.0)(supports-color@5.5.0))(express@5.2.1)
-      '@better-auth/passkey':
-        specifier: 1.6.26
-        version: 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.26(mongodb@7.5.0)(vitest@4.1.11))(better-call@1.3.7(zod@4.3.6))(nanostores@1.1.1)
       '@getbrevo/brevo':
         specifier: 6.0.3
         version: 6.0.3
@@ -85,9 +82,6 @@ importers:
       bcrypt:
         specifier: 6.0.0
         version: 6.0.0
-      better-auth:
-        specifier: 1.6.26
-        version: 1.6.26(mongodb@7.5.0)(vitest@4.1.11)
       class-transformer:
         specifier: 0.5.1
         version: 0.5.1
@@ -188,6 +182,12 @@ importers:
       '@aws-sdk/s3-request-presigner':
         specifier: 3.1115.0
         version: 3.1115.0
+      '@better-auth/core':
+        specifier: 1.7.1
+        version: 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.5.2)
+      '@better-auth/passkey':
+        specifier: 1.7.1
+        version: 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.5.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.7.1(mongodb@7.5.0)(vitest@4.1.11))(better-call@1.4.0(zod@4.3.6))(nanostores@1.5.2)
       '@compodoc/compodoc':
         specifier: 2.0.0
         version: 2.0.0(component-emitter@1.3.1)(typescript@5.9.3)
@@ -242,6 +242,9 @@ importers:
       ansi-colors:
         specifier: 4.1.3
         version: 4.1.3
+      better-auth:
+        specifier: 1.7.1
+        version: 1.7.1(mongodb@7.5.0)(vitest@4.1.11)
       bullmq:
         specifier: 6.2.0
         version: 6.2.0(ioredis@6.0.0(supports-color@5.5.0))
@@ -554,14 +557,14 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@better-auth/core@1.6.26':
-    resolution: {integrity: sha512-Ud4FqnjIJDvmeo+3bN+OsuVVAiuvFjNERbW7G8/65ictSxCox62gNgTOsJ4YXmbwXzBzyyekStzrupg2qNGEkA==}
+  '@better-auth/core@1.7.1':
+    resolution: {integrity: sha512-eZ9lqcnVLMZ3QtUByRo4VZqkB1ESyRddd9NfWjBdDPgh+jcwLScoIUAqhtHLR8zaSUJZah8OLGlkzObyPdUH7A==}
     peerDependencies:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@cloudflare/workers-types': '>=4'
       '@opentelemetry/api': ^1.9.0
-      better-call: 1.3.7
+      better-call: 1.4.0
       jose: ^6.1.0
       kysely: ^0.28.5 || ^0.29.0
       nanostores: ^1.0.1
@@ -571,56 +574,56 @@ packages:
       '@opentelemetry/api':
         optional: true
 
-  '@better-auth/drizzle-adapter@1.6.26':
-    resolution: {integrity: sha512-SMvAeeUqEsz0BLtWVVp+HdStAVOwcxs4vPkL/AVmFJ0e9dDKItXl881xWeB/Ze4NgBW6NYmUId9qI4LrdQu3hA==}
+  '@better-auth/drizzle-adapter@1.7.1':
+    resolution: {integrity: sha512-qlqNyg5V9bXHSP68/vtlsiZayhR4hgvEGiS/E3SIj8bCpWWFGmyQkxJbQCqpBmC7vT30wE/kNtJMHIgnV3rkiw==}
     peerDependencies:
-      '@better-auth/core': ^1.6.26
+      '@better-auth/core': ^1.7.1
       '@better-auth/utils': 0.4.2
-      drizzle-orm: ^0.45.2
+      drizzle-orm: ^0.45.2 || >=1.0.0-rc.1 <2.0.0
     peerDependenciesMeta:
       drizzle-orm:
         optional: true
 
-  '@better-auth/kysely-adapter@1.6.26':
-    resolution: {integrity: sha512-Y0Kdqn8JQMR8dHMtUnbBNqq7Mk8mDf18DwTves2uhjtRfcOWByVTGxsFMDVUbedMuoM+Ab+v04bwCk94sAo8NA==}
+  '@better-auth/kysely-adapter@1.7.1':
+    resolution: {integrity: sha512-yWCpE1cZpMUj37nD6JFDK+GDR8zS37L5WI73il3qbU9TXtWsxUQKc/5c3IHsHizWQsmcQI8uv2pAFKxsRDa+AQ==}
     peerDependencies:
-      '@better-auth/core': ^1.6.26
+      '@better-auth/core': ^1.7.1
       '@better-auth/utils': 0.4.2
       kysely: ^0.28.17 || ^0.29.0
     peerDependenciesMeta:
       kysely:
         optional: true
 
-  '@better-auth/memory-adapter@1.6.26':
-    resolution: {integrity: sha512-kb5ahphEp9jyMleXU4T8I/xgWPa8gjOLFKKsnaVqR/BU+h7xqTOsjJwTY3evY+PFYHvjNFUlrjZ1Km8A/w1p/w==}
+  '@better-auth/memory-adapter@1.7.1':
+    resolution: {integrity: sha512-6NX1yv88DeqdoG7owYFqKwlrDGaIPhsC52JUGrUgeGVKyOq8a/6hHlHsqG1C2FwT23SHQiKVYCEAG9N6aH5OvQ==}
     peerDependencies:
-      '@better-auth/core': ^1.6.26
+      '@better-auth/core': ^1.7.1
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/mongo-adapter@1.6.26':
-    resolution: {integrity: sha512-jYGhuIQqj48h69ROLPYdc8jgqDaMmRRLLFiRViZFYarNyBuYUV07DywJXvRuw8l9ADx+M1TB+BJZGnLE2nnmwQ==}
+  '@better-auth/mongo-adapter@1.7.1':
+    resolution: {integrity: sha512-9ILTcNqhG37QK//qR4UhYLyKzNqq6w6zVTf5KX6xkiTjNcV7Oh1yS31lkIJEVTqRNcy9AoV6FZMW6Bbsm8IMDA==}
     peerDependencies:
-      '@better-auth/core': ^1.6.26
+      '@better-auth/core': ^1.7.1
       '@better-auth/utils': 0.4.2
       mongodb: ^6.0.0 || ^7.0.0
     peerDependenciesMeta:
       mongodb:
         optional: true
 
-  '@better-auth/passkey@1.6.26':
-    resolution: {integrity: sha512-qEnXvh5QPHVnqigNBJq/Qur+U9eCa2t4kgdJL+xKEZ4IOxvx55WiGkneNAzIuR7n5saTF6iWtmsbSwMAkWAl9w==}
+  '@better-auth/passkey@1.7.1':
+    resolution: {integrity: sha512-bGnCBDL2udKniHI4IZpjh4lU8lQWRVk3SG/ZtTtZz6QZLCJ2YpVjjwv2O0VJt/jw9SLuXyccx3IFh4s0PKGTRQ==}
     peerDependencies:
-      '@better-auth/core': ^1.6.26
+      '@better-auth/core': ^1.7.1
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
-      better-auth: ^1.6.26
-      better-call: 1.3.7
+      better-auth: ^1.7.1
+      better-call: 1.4.0
       nanostores: ^1.0.1
 
-  '@better-auth/prisma-adapter@1.6.26':
-    resolution: {integrity: sha512-ILQoYmnoYyghDP4iN1h/Gkd9Jt7Xs/vxoNAt4AuuJJbqs73u27LlQM4P1YiP7nJ+bM1iVTBI1dDF73myIAtjzQ==}
+  '@better-auth/prisma-adapter@1.7.1':
+    resolution: {integrity: sha512-ZiUcafQ85InAofcUjyGgCPjKLfQjXr9SvDmMjuFUW8oEbreA6C6GaFAEA77VuV2doZUQlzvQQ4gCoTmS28W92A==}
     peerDependencies:
-      '@better-auth/core': ^1.6.26
+      '@better-auth/core': ^1.7.1
       '@better-auth/utils': 0.4.2
       '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
       prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
@@ -630,15 +633,18 @@ packages:
       prisma:
         optional: true
 
-  '@better-auth/telemetry@1.6.26':
-    resolution: {integrity: sha512-pBs69RORUSJHRF9r5PdeY7pzLRga09YSWew8igFYrBvT2tLt7DktrbD5WjryLZpAZOuKAMZ+Xo0DlJbnvLWGpQ==}
+  '@better-auth/telemetry@1.7.1':
+    resolution: {integrity: sha512-kLKjMfFlTbyt49DGeI9okHAsn0MtBZcMoQYKaEdgR0H3BHzqqyzePcQz/hxAmRgjB4p/6inise3zJwhX0sgXrQ==}
     peerDependencies:
-      '@better-auth/core': ^1.6.26
+      '@better-auth/core': ^1.7.1
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
   '@better-auth/utils@0.4.2':
     resolution: {integrity: sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==}
+
+  '@better-auth/utils@0.5.0':
+    resolution: {integrity: sha512-BL8W4EfIZFwlu0r54m3v1ztjDhu6dDe/amLTm0xybmbZaNgYUqhD3SjpAsnq0q8YD6/ki4iwIgxJNLP/N3TxiA==}
 
   '@better-fetch/fetch@1.3.1':
     resolution: {integrity: sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==}
@@ -1434,8 +1440,8 @@ packages:
       '@nestjs/platform-express':
         optional: true
 
-  '@noble/ciphers@2.1.1':
-    resolution: {integrity: sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==}
+  '@noble/ciphers@2.3.0':
+    resolution: {integrity: sha512-Clu/xdfgVTf9o7ngLOURaxePwR0j8sjclKEtVij10/jGulwFsPWCvvRgG/XjUVf8Nei+jLG6uwyXzUTGY1DQrw==}
     engines: {node: '>= 20.19.0'}
 
   '@noble/hashes@1.8.0':
@@ -1446,8 +1452,8 @@ packages:
     resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
     engines: {node: '>= 20.19.0'}
 
-  '@opentelemetry/semantic-conventions@1.40.0':
-    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
     engines: {node: '>=14'}
 
   '@oxc-project/types@0.146.0':
@@ -1899,11 +1905,11 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
-  '@simplewebauthn/browser@13.2.2':
-    resolution: {integrity: sha512-FNW1oLQpTJyqG5kkDg5ZsotvWgmBaC6jCHR7Ej0qUNep36Wl9tj2eZu7J5rP+uhXgHaLk+QQ3lqcw2vS5MX1IA==}
+  '@simplewebauthn/browser@13.3.0':
+    resolution: {integrity: sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==}
 
-  '@simplewebauthn/server@13.2.3':
-    resolution: {integrity: sha512-ZhcVBOw63birYx9jVfbhK6rTehckVes8PeWV324zpmdxr0BUfylospwMzcrxrdMcOi48MHWj2LCA+S528LnGvg==}
+  '@simplewebauthn/server@13.3.2':
+    resolution: {integrity: sha512-KEDhfcGP1PAKRVSDjA3npTQFqS2b/srm+ipoNBNHdkzrHAlaRQUTE+a5f4ywsx6thxAw1NU2rYcLEY1949RGbQ==}
     engines: {node: '>=20.0.0'}
 
   '@sindresorhus/is@7.2.0':
@@ -2496,8 +2502,8 @@ packages:
     resolution: {integrity: sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==}
     engines: {node: '>= 18'}
 
-  better-auth@1.6.26:
-    resolution: {integrity: sha512-nhXWrDDj+EnZsHq1j0z1c6DowOMFZWZHe6LCaXbBfLIgHHZm6dyazBQcbRspM4spUIcUt250Mc1BFOSuP7eniQ==}
+  better-auth@1.7.1:
+    resolution: {integrity: sha512-g8WlTQijxXWJjPVZfFu1+EJg9cwwHrKDmIkcYMzx8CzYA+tDxl6NI7qQbKkbgw5UtHILsT5VH+RMzFzwnVJqAg==}
     peerDependencies:
       '@lynx-js/react': '*'
       '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
@@ -2505,8 +2511,8 @@ packages:
       '@tanstack/react-start': ^1.0.0
       '@tanstack/solid-start': ^1.0.0
       better-sqlite3: ^12.0.0
-      drizzle-kit: '>=0.31.4'
-      drizzle-orm: ^0.45.2
+      drizzle-kit: '>=0.31.4 || >=1.0.0-beta.1'
+      drizzle-orm: ^0.45.2 || >=1.0.0-rc.1 <2.0.0
       mongodb: ^6.0.0 || ^7.0.0
       mysql2: ^3.0.0
       next: ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -2558,8 +2564,8 @@ packages:
       vue:
         optional: true
 
-  better-call@1.3.7:
-    resolution: {integrity: sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==}
+  better-call@1.4.0:
+    resolution: {integrity: sha512-bBKOT4vv1kZLDgxVePdilk/Jwkn+dtRRsmi3DzHcDP+WnswyVl6dR59l2HEeP/0cB+bDoopASAesWDPIdd/zZA==}
     peerDependencies:
       zod: ^4.0.0
     peerDependenciesMeta:
@@ -4100,8 +4106,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanostores@1.1.1:
-    resolution: {integrity: sha512-EYJqS25r2iBeTtGQCHidXl1VfZ1jXM7Q04zXJOrMlxVVmD0ptxJaNux92n1mJ7c5lN3zTq12MhH/8x59nP+qmg==}
+  nanostores@1.5.2:
+    resolution: {integrity: sha512-B0UbxzK1s0CN8Xht6r+7iT5+xV8PTaRERR1nATeplRv1Rw5YLWfVAid0hkqY3EceqpG4RjTk8GAwIxQY39Rnwg==}
     engines: {node: ^20.0.0 || >=22.0.0}
 
   negotiator@0.6.4:
@@ -4504,8 +4510,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rou3@0.7.12:
-    resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
+  rou3@0.9.2:
+    resolution: {integrity: sha512-3SOzvaAg8rkHrXtRjpCvCvbyO5to9oOO27Z/XqHEYXfMRVSw/qMIVdmaOk9W2lcRLtR6dlqTjo9hDeJk70QBYQ==}
 
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
@@ -4564,8 +4570,8 @@ packages:
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
-  set-cookie-parser@3.0.1:
-    resolution: {integrity: sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q==}
+  set-cookie-parser@3.1.2:
+    resolution: {integrity: sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -5702,66 +5708,70 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.1.1)':
+  '@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.5.2)':
     dependencies:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
-      '@opentelemetry/semantic-conventions': 1.40.0
+      '@opentelemetry/semantic-conventions': 1.43.0
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.7(zod@4.3.6)
+      better-call: 1.4.0(zod@4.3.6)
       jose: 6.2.9
       kysely: 0.28.17
-      nanostores: 1.1.1
+      nanostores: 1.5.2
       zod: 4.3.6
 
-  '@better-auth/drizzle-adapter@1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.2)':
+  '@better-auth/drizzle-adapter@1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.5.2))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.1.1)
+      '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.5.2)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/kysely-adapter@1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.2)(kysely@0.28.17)':
+  '@better-auth/kysely-adapter@1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.5.2))(@better-auth/utils@0.4.2)(kysely@0.28.17)':
     dependencies:
-      '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.1.1)
+      '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.5.2)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       kysely: 0.28.17
 
-  '@better-auth/memory-adapter@1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.2)':
+  '@better-auth/memory-adapter@1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.5.2))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.1.1)
+      '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.5.2)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/mongo-adapter@1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.2)(mongodb@7.5.0)':
+  '@better-auth/mongo-adapter@1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.5.2))(@better-auth/utils@0.4.2)(mongodb@7.5.0)':
     dependencies:
-      '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.1.1)
+      '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.5.2)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       mongodb: 7.5.0
 
-  '@better-auth/passkey@1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.26(mongodb@7.5.0)(vitest@4.1.11))(better-call@1.3.7(zod@4.3.6))(nanostores@1.1.1)':
+  '@better-auth/passkey@1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.5.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.7.1(mongodb@7.5.0)(vitest@4.1.11))(better-call@1.4.0(zod@4.3.6))(nanostores@1.5.2)':
     dependencies:
-      '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.1.1)
+      '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.5.2)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
-      '@simplewebauthn/browser': 13.2.2
-      '@simplewebauthn/server': 13.2.3
-      better-auth: 1.6.26(mongodb@7.5.0)(vitest@4.1.11)
-      better-call: 1.3.7(zod@4.3.6)
-      nanostores: 1.1.1
+      '@simplewebauthn/browser': 13.3.0
+      '@simplewebauthn/server': 13.3.2
+      better-auth: 1.7.1(mongodb@7.5.0)(vitest@4.1.11)
+      better-call: 1.4.0(zod@4.3.6)
+      nanostores: 1.5.2
       zod: 4.3.6
 
-  '@better-auth/prisma-adapter@1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.2)':
+  '@better-auth/prisma-adapter@1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.5.2))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.1.1)
+      '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.5.2)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/telemetry@1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+  '@better-auth/telemetry@1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.5.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
     dependencies:
-      '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.1.1)
+      '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.5.2)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
   '@better-auth/utils@0.4.2':
+    dependencies:
+      '@noble/hashes': 2.2.0
+
+  '@better-auth/utils@0.5.0':
     dependencies:
       '@noble/hashes': 2.2.0
 
@@ -6451,13 +6461,13 @@ snapshots:
     optionalDependencies:
       '@nestjs/platform-express': 11.2.1(@nestjs/common@11.2.1(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.2.1)
 
-  '@noble/ciphers@2.1.1': {}
+  '@noble/ciphers@2.3.0': {}
 
   '@noble/hashes@1.8.0': {}
 
   '@noble/hashes@2.2.0': {}
 
-  '@opentelemetry/semantic-conventions@1.40.0': {}
+  '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@oxc-project/types@0.146.0': {}
 
@@ -6764,9 +6774,9 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
-  '@simplewebauthn/browser@13.2.2': {}
+  '@simplewebauthn/browser@13.3.0': {}
 
-  '@simplewebauthn/server@13.2.3':
+  '@simplewebauthn/server@13.3.2':
     dependencies:
       '@hexagon/base64': 1.1.28
       '@levischuck/tiny-cbor': 0.2.11
@@ -7470,24 +7480,24 @@ snapshots:
       node-addon-api: 8.6.0
       node-gyp-build: 4.8.4
 
-  better-auth@1.6.26(mongodb@7.5.0)(vitest@4.1.11):
+  better-auth@1.7.1(mongodb@7.5.0)(vitest@4.1.11):
     dependencies:
-      '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.1.1)
-      '@better-auth/drizzle-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.2)
-      '@better-auth/kysely-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.2)(kysely@0.28.17)
-      '@better-auth/memory-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.2)(mongodb@7.5.0)
-      '@better-auth/prisma-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.2)
-      '@better-auth/telemetry': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.1.1))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.5.2)
+      '@better-auth/drizzle-adapter': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.5.2))(@better-auth/utils@0.4.2)
+      '@better-auth/kysely-adapter': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.5.2))(@better-auth/utils@0.4.2)(kysely@0.28.17)
+      '@better-auth/memory-adapter': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.5.2))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.5.2))(@better-auth/utils@0.4.2)(mongodb@7.5.0)
+      '@better-auth/prisma-adapter': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.5.2))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.5.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
-      '@noble/ciphers': 2.1.1
+      '@noble/ciphers': 2.3.0
       '@noble/hashes': 2.2.0
-      better-call: 1.3.7(zod@4.3.6)
+      better-call: 1.4.0(zod@4.3.6)
       defu: 6.1.7
       jose: 6.2.9
       kysely: 0.28.17
-      nanostores: 1.1.1
+      nanostores: 1.5.2
       zod: 4.3.6
     optionalDependencies:
       mongodb: 7.5.0
@@ -7496,12 +7506,12 @@ snapshots:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
 
-  better-call@1.3.7(zod@4.3.6):
+  better-call@1.4.0(zod@4.3.6):
     dependencies:
-      '@better-auth/utils': 0.4.2
+      '@better-auth/utils': 0.5.0
       '@better-fetch/fetch': 1.3.1
-      rou3: 0.7.12
-      set-cookie-parser: 3.0.1
+      rou3: 0.9.2
+      set-cookie-parser: 3.1.2
     optionalDependencies:
       zod: 4.3.6
 
@@ -8977,7 +8987,7 @@ snapshots:
 
   nanoid@3.3.18: {}
 
-  nanostores@1.1.1: {}
+  nanostores@1.5.2: {}
 
   negotiator@0.6.4: {}
 
@@ -9384,7 +9394,7 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.2.5
       '@rolldown/binding-win32-x64-msvc': 1.2.5
 
-  rou3@0.7.12: {}
+  rou3@0.9.2: {}
 
   router@2.2.0:
     dependencies:
@@ -9462,7 +9472,7 @@ snapshots:
 
   set-cookie-parser@2.7.2: {}
 
-  set-cookie-parser@3.0.1: {}
+  set-cookie-parser@3.1.2: {}
 
   set-function-length@1.2.2:
     dependencies:

--- a/scripts/check-mutations.mjs
+++ b/scripts/check-mutations.mjs
@@ -53,11 +53,11 @@
  * refactor three modules away can hollow out a test it will happily skip — which is exactly the
  * failure this tool exists to catch. Fast feedback while you work; never the evidence.
  *
- * Why the release gate still runs all 53 rather than caching per-mutation verdicts: the gate runs
+ * Why the release gate still runs all 56 rather than caching per-mutation verdicts: the gate runs
  * ONCE PER RELEASE, not per commit, so the saving is ~10 minutes a release. The price would be a
  * cache that has to model each spec's full dependency closure correctly, and the failure mode of
  * getting that wrong is a stale PASS for a test that has since gone vacuous — the precise thing the
- * gate is there to prevent. Bad trade at 53 mutations. Revisit around 100, where the full run
+ * gate is there to prevent. Bad trade at 56 mutations. Revisit around 100, where the full run
  * approaches half an hour.
  *
  * PARALLELISM

--- a/spectaql.yml
+++ b/spectaql.yml
@@ -19,7 +19,7 @@ servers:
 info:
   title: lT Nest Server
   description: Modern, fast, powerful Node.js web framework in TypeScript based on Nest with a GraphQL API and a connection to MongoDB (or other databases).
-  version: 11.36.5
+  version: 11.37.0
   contact:
     name: lenne.Tech GmbH
     url: https://lenne.tech

--- a/src/core/modules/better-auth/INTEGRATION-CHECKLIST.md
+++ b/src/core/modules/better-auth/INTEGRATION-CHECKLIST.md
@@ -2,13 +2,36 @@
 
 **For integrating BetterAuth into projects using `@lenne.tech/nest-server`.**
 
-> **Estimated time:** 10-15 minutes
+> **Estimated time:** 10-15 minutes (plus Step 0 on a fresh integration)
 
 **Need customization?** See [CUSTOMIZATION.md](./CUSTOMIZATION.md) for:
 
 - Module registration patterns (Zero-Config, Config-based, Separate Module)
 - Controller, Resolver, and Service customization
 - Email template customization
+
+---
+
+## Step 0: Install the Peer Dependencies (required from 11.37.0)
+
+From `@lenne.tech/nest-server` 11.37.0, better-auth is **not** a dependency of this package. It is a
+non-optional **peer dependency**, so your project declares and owns the version:
+
+```bash
+pnpm add better-auth@1.7.1 @better-auth/passkey@1.7.1 @better-auth/core@1.7.1
+```
+
+**Pin all three to the same exact version** — no `^`, no `~`. They are one release train, and a
+mixed set fails in ways the type checker does not catch.
+
+> **Do not rely on `pnpm install` to remind you.** On pnpm's default `autoInstallPeers: true` the
+> packages are installed silently at whatever version satisfies `>=1.7.1 <1.8.0` — your build stays
+> green while the version is unpinned and free to drift. Verify with `pnpm why better-auth`.
+
+**Why peers rather than dependencies:** in a fullstack project the frontend talks to better-auth
+too. When this package owned the version, the API and the app could silently end up on different
+better-auth versions with incompatible payload shapes. Owning it in your own manifest makes that a
+single, visible decision.
 
 ---
 

--- a/src/core/modules/better-auth/README.md
+++ b/src/core/modules/better-auth/README.md
@@ -30,6 +30,7 @@ const config = {
 - [Features](#features)
 - [Quick Integration](#quick-integration-for-claude-code--ai-assistants)
 - [Project Integration Guide](#project-integration-guide-required-steps)
+- [Boot-Time Behaviour](#boot-time-behaviour)
 - [Configuration](#configuration)
 - [REST API Endpoints](#rest-api-endpoints)
 - [GraphQL API](#graphql-api)
@@ -1015,6 +1016,61 @@ const config = {
 - Full flexibility for specialized plugins
 - No package updates needed for new Better-Auth plugins
 
+## Boot-Time Behaviour
+
+`CoreBetterAuthService.onModuleInit()` runs two steps against the database before the application
+starts listening. Both are `protected`, so a subclass can override either — **an override of
+`onModuleInit()` that does not call `super.onModuleInit()` skips both.**
+
+### 1. `ensureIndices()` — performance
+
+Idempotent indices on `session`, `users`, `account` and `verification`, including a TTL index that
+expires unconsumed verification and password-reset documents. Failures are logged at `warn` and do
+not block the boot: these help speed, not correctness.
+
+### 2. `backfillAccountIssuers()` — correctness (11.37.0+)
+
+From better-auth 1.7 an account is keyed by `(issuer, accountId)` and the sign-in route filters on
+it verbatim. Rows written by better-auth 1.6 have no `issuer` field, so **every existing password
+user would be locked out by the upgrade**, with a bare 401 and nothing in the log to explain it.
+This step repairs those rows on the first boot after the upgrade.
+
+| Property         | Behaviour                                                                                                                                                                                    |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Scope            | Credential accounts only. OAuth/SSO rows are reported, never rewritten — see below                                                                                                           |
+| Idempotency      | Structural: only rows missing the field are selected                                                                                                                                         |
+| Repeat cost      | A completion marker in `better-auth-backfills` short-circuits later boots to one `_id` lookup. Neither backfill query is indexable, so without it every boot would scan the whole collection |
+| Schema overrides | Collection and field names are resolved from the running better-auth instance; a customised name is logged at `warn`                                                                         |
+| Partial failure  | The write is unordered, so one bad row cannot shadow the rest. The marker is **not** written, and the next boot retries                                                                      |
+| Failure          | Logged at `error`; the boot continues. A server that starts with a loud error beats one that will not start                                                                                  |
+
+**Log lines to expect on the first boot after upgrading:**
+
+| Line                                                           | Meaning                                                                                                |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `Backfilled account.issuer on N credential account(s)`         | Success — those N users can sign in again                                                              |
+| `Backfilled N/M credential accounts. X user(s) CANNOT sign in` | Partial. Usually a duplicate `(issuer, accountId)` pair from an earlier migration. Resolve and restart |
+| `Could not backfill the account issuer: …`                     | The operation failed entirely. Affected users cannot sign in until it succeeds                         |
+| `At least one non-credential account has no "issuer"`          | See below — act before the next social sign-in                                                         |
+| `Backfilling the account issuer against a customised schema`   | You renamed the account model or issuer field                                                          |
+
+**Why OAuth/SSO rows are not backfilled.** `local:credential` is a pure function of the provider id
+and therefore derivable. An OAuth issuer is not — it is either the provider's real OIDC issuer or
+the synthetic `local:oauth:<providerId>` fallback, decided per provider. Guessing would not fail
+loudly: better-auth falls back to matching the user by the provider-asserted email and implicitly
+links a **second** account row; if that email has changed, it creates a **new user** and orphans the
+old account together with its provider tokens, which no unlink will ever remove. So those rows are
+reported and the decision stays with the project. Set the issuer per provider **before** the first
+social sign-in after the upgrade — see
+[migration-guides/11.36.x-to-11.37.0.md](../../../../migration-guides/11.36.x-to-11.37.0.md) §4.
+
+> **Do not add `issuer` to this package's own reads of the `account` collection**
+> (`syncPasswordChangeToIam`, `migrateAccountToIam`, `getMigrationStatus`). They filter on
+> `providerId` alone on purpose, so they keep working on rows the backfill has not reached yet —
+> which matters most when the backfill has failed.
+
+---
+
 ## Module Setup
 
 See the [Project Integration Guide](#project-integration-guide-required-steps) at the top of this document for complete step-by-step instructions.
@@ -1893,6 +1949,14 @@ When a user is deleted:
    ```javascript
    // MongoDB query
    db.account.findOne({ userId: ObjectId('...'), providerId: 'credential' });
+   ```
+
+   From better-auth 1.7 the row must ALSO carry `issuer: 'local:credential'`. A row matching only
+   `providerId` is not usable — better-auth keys accounts by `(issuer, accountId)` and will not find
+   it, so sign-in answers 401 while this query happily reports that the account exists:
+
+   ```javascript
+   db.account.findOne({ issuer: 'local:credential', providerId: 'credential', userId: ObjectId('...') });
    ```
 
 3. Check server logs for sync warnings:

--- a/src/core/modules/better-auth/core-better-auth-user.mapper.ts
+++ b/src/core/modules/better-auth/core-better-auth-user.mapper.ts
@@ -1,3 +1,4 @@
+import { createLocalAccountIssuer } from '@better-auth/core/db';
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { InjectConnection } from '@nestjs/mongoose';
 import * as bcrypt from 'bcrypt';
@@ -509,10 +510,16 @@ export class CoreBetterAuthUserMapper {
       // Store account matching Better-Auth's format:
       // - userId: ObjectId referencing users._id
       // - accountId: string version of users._id
+      // - issuer: from better-auth >= 1.7 accounts are keyed by (issuer,
+      //   accountId), and credential accounts carry a synthetic issuer. Writing
+      //   the row without it produces an account better-auth cannot find, so the
+      //   migrated user gets a 401 on the very sign-in that triggered the
+      //   migration. Always derive it from the helper, never hand-write it.
       await accountsCollection.insertOne({
         accountId: userIdHex,
         createdAt: now,
         id: this.generateId(),
+        issuer: createLocalAccountIssuer('credential'),
         password: passwordHash,
         providerId: 'credential',
         updatedAt: now,

--- a/src/core/modules/better-auth/core-better-auth.constants.ts
+++ b/src/core/modules/better-auth/core-better-auth.constants.ts
@@ -71,3 +71,29 @@ export const BETTER_AUTH_CONFIG = 'BETTER_AUTH_CONFIG';
  * Declared `@Optional()` in the CoreBetterAuthService constructor.
  */
 export const BETTER_AUTH_COOKIE_DOMAIN = 'BETTER_AUTH_COOKIE_DOMAIN';
+
+/**
+ * better-auth's default name for the account collection, and for the `issuer` field inside it.
+ *
+ * Both are overridable by a consumer through `betterAuth.options.account.modelName` /
+ * `.fields.issuer`, which `better-auth.config.ts` spreads onto the resolved config verbatim. Any
+ * framework code touching that collection directly MUST resolve the real names from the running
+ * instance and fall back to these — a hardcoded name silently addresses a collection better-auth
+ * does not use, which on the issuer backfill means every password user stays locked out while the
+ * operation reports success by saying nothing.
+ */
+export const DEFAULT_ACCOUNT_MODEL_NAME = 'account';
+export const DEFAULT_ACCOUNT_ISSUER_FIELD = 'issuer';
+
+/**
+ * Collection holding one-shot completion markers for boot-time data migrations, and the marker id
+ * of the `account.issuer` backfill (better-auth 1.7).
+ *
+ * The marker exists for cost, not for correctness: the backfill is idempotent and safe to repeat,
+ * but its filters (`$exists: false`, `$ne`) cannot use an index, so without a marker every boot of
+ * every replica pays a full pass over the account collection — forever, and inside the `await` that
+ * precedes `app.listen()`. Versioned in the id so a future backfill of the same field can run
+ * again without clearing this one.
+ */
+export const BACKFILL_MARKER_COLLECTION = 'better-auth-backfills';
+export const ACCOUNT_ISSUER_BACKFILL_ID = 'account-issuer-backfill-v1';

--- a/src/core/modules/better-auth/core-better-auth.service.ts
+++ b/src/core/modules/better-auth/core-better-auth.service.ts
@@ -1,3 +1,4 @@
+import { createLocalAccountIssuer } from '@better-auth/core/db';
 import { BadRequestException, Inject, Injectable, Logger, OnModuleInit, Optional } from '@nestjs/common';
 import { InjectConnection } from '@nestjs/mongoose';
 import { Request } from 'express';
@@ -14,7 +15,15 @@ import { BetterAuthInstance } from './better-auth.config';
 import { isJwtShaped } from './core-better-auth-token.helper';
 import { BetterAuthSessionUser } from './core-better-auth-user.mapper';
 import { convertExpressHeaders, parseCookieHeader, signCookieValueIfNeeded } from './core-better-auth-web.helper';
-import { BETTER_AUTH_CONFIG, BETTER_AUTH_COOKIE_DOMAIN, BETTER_AUTH_INSTANCE } from './core-better-auth.constants';
+import {
+  ACCOUNT_ISSUER_BACKFILL_ID,
+  BACKFILL_MARKER_COLLECTION,
+  BETTER_AUTH_CONFIG,
+  BETTER_AUTH_COOKIE_DOMAIN,
+  BETTER_AUTH_INSTANCE,
+  DEFAULT_ACCOUNT_ISSUER_FIELD,
+  DEFAULT_ACCOUNT_MODEL_NAME,
+} from './core-better-auth.constants';
 
 /**
  * Result of a session validation
@@ -94,11 +103,30 @@ export class CoreBetterAuthService implements OnModuleInit {
   }
 
   /**
-   * Ensure performance indices exist on the session, users, account and verification collections.
-   * Indices are idempotent — calling createIndex on an existing index is a no-op.
+   * Boot steps for the better-auth integration.
+   *
+   * Two jobs live here and they are deliberately separate methods: ensuring indices is a
+   * PERFORMANCE concern that repeats forever and degrades gracefully (hence `warn`), while the
+   * issuer backfill is a CORRECTNESS concern that should happen once and locks users out when it
+   * does not (hence `error`). Keeping them in one method made those two severities look like one
+   * decision.
+   *
+   * Order matters: the backfill's update can use the `{ providerId: 1, userId: 1 }` index created
+   * below, so indices come first.
    */
   async onModuleInit(): Promise<void> {
     if (!this.isEnabled() || !this.connection?.db) return;
+
+    await this.ensureIndices();
+    await this.backfillAccountIssuers();
+  }
+
+  /**
+   * Ensure performance indices exist on the session, users, account and verification collections.
+   * Indices are idempotent — calling createIndex on an existing index is a no-op.
+   */
+  protected async ensureIndices(): Promise<void> {
+    if (!this.connection?.db) return;
 
     try {
       const db = this.connection.db;
@@ -127,6 +155,154 @@ export class CoreBetterAuthService implements OnModuleInit {
     } catch (error) {
       // Non-fatal: indices improve performance but are not required for correctness
       this.logger.warn(`Could not create performance indices: ${error instanceof Error ? error.message : 'unknown'}`);
+    }
+  }
+
+  /**
+   * Backfills `account.issuer` on rows written before better-auth 1.7.
+   *
+   * From 1.7 an account is keyed by (issuer, accountId), and sign-in filters on
+   * it verbatim:
+   *
+   *   account.providerId === 'credential' && account.issuer === credentialIssuer
+   *
+   * A row written by 1.6 has no `issuer` at all, so that comparison can never
+   * hold: every existing password user would be locked out by the upgrade
+   * itself, with a 401 and nothing in the logs to explain it. This closes that
+   * gap on the first boot after the upgrade.
+   *
+   * Idempotent — the filter only matches rows still missing the field, so the
+   * second start updates nothing.
+   *
+   * Scope is deliberately limited to credential accounts, where the issuer is
+   * derivable without guessing. OAuth accounts are NOT touched: their issuer
+   * depends on the provider (a real OIDC issuer, or the synthetic
+   * `local:oauth:<id>` fallback), and writing the wrong one would not fail
+   * loudly — it would create a second account on the next social sign-in. Those
+   * rows are reported instead, so the decision stays with the project.
+   *
+   * ONE THING NOT TO "TIDY UP": this package's own reads of the `account`
+   * collection filter on `providerId` alone — `syncPasswordChangeToIam`,
+   * `migrateAccountToIam` and `getMigrationStatus` in
+   * core-better-auth-user.mapper.ts. Adding `issuer` to those filters looks like
+   * consistency and is a regression. This backfill is deliberately NON-FATAL: if
+   * it fails, the server still boots and logs an error. Reads that do not require
+   * the field keep working on un-backfilled rows — `getMigrationStatus` would
+   * otherwise report zero migrated users, and `syncPasswordChangeToIam` would
+   * stop finding the account it is meant to update. Only better-auth's own
+   * sign-in path needs the issuer, and that one is better-auth's code, not ours.
+   */
+  protected async backfillAccountIssuers(): Promise<void> {
+    if (!this.isEnabled() || !this.connection?.db) return;
+
+    const db = this.connection.db;
+
+    // The consumer can rename both of these through `betterAuth.options.account`, which
+    // better-auth.config.ts spreads onto the resolved config verbatim. Hardcoding them turns this
+    // whole method into a silent no-op on such a project: nothing matches, `modifiedCount` is 0,
+    // neither log line fires, and every password user is locked out while the operator's upgrade
+    // checklist is satisfied by silence in both directions.
+    const accountOptions = (this.authInstance as any)?.options?.account;
+    const modelName: string = accountOptions?.modelName ?? DEFAULT_ACCOUNT_MODEL_NAME;
+    const issuerField: string = accountOptions?.fields?.issuer ?? DEFAULT_ACCOUNT_ISSUER_FIELD;
+
+    try {
+      const accounts = db.collection(modelName);
+
+      // A completion marker, checked before anything expensive. Without it both queries below run
+      // on EVERY boot of EVERY replica, forever — and neither is indexable (`$exists: false` cannot
+      // appear in a partialFilterExpression, `$ne` is not selective), so each is a full pass over
+      // the account collection, awaited before the app starts listening. With the marker the steady
+      // state is a single `_id` lookup. `system-setup-locks` in CoreSystemSetupService is the
+      // precedent for this kind of once-per-deployment boot state.
+      const markers = db.collection(BACKFILL_MARKER_COLLECTION);
+      if (await markers.findOne({ _id: ACCOUNT_ISSUER_BACKFILL_ID as any })) {
+        this.logger.debug(`account.${issuerField} backfill already completed — skipping.`);
+        return;
+      }
+
+      if (modelName !== DEFAULT_ACCOUNT_MODEL_NAME || issuerField !== DEFAULT_ACCOUNT_ISSUER_FIELD) {
+        this.logger.warn(
+          `Backfilling the account issuer against a customised schema (collection "${modelName}", ` +
+            `field "${issuerField}"). Verify these match what better-auth actually writes.`,
+        );
+      }
+
+      const pending = await accounts
+        .find({ [issuerField]: { $exists: false }, providerId: 'credential' }, { projection: { _id: 1 } })
+        .toArray();
+
+      let backfilled = 0;
+
+      if (pending.length) {
+        // `ordered: false` is load-bearing. better-auth declares a UNIQUE index on
+        // (issuer, accountId); a single pre-existing duplicate would abort an ordered write and
+        // leave every row after it untouched — those users stay locked out, with one log line and
+        // a green boot. Unordered, one bad row costs only itself.
+        const result = await accounts.bulkWrite(
+          pending.map((doc) => ({
+            updateOne: {
+              filter: { _id: doc._id },
+              update: { $set: { [issuerField]: createLocalAccountIssuer('credential') } },
+            },
+          })),
+          { ordered: false },
+        );
+
+        backfilled = result.modifiedCount;
+
+        if (backfilled > 0) {
+          this.logger.log(
+            `Backfilled account.${issuerField} on ${backfilled} credential account(s) for better-auth >= 1.7. ` +
+              'Without it these users could not sign in.',
+          );
+        }
+
+        if (backfilled < pending.length) {
+          // Do NOT write the marker in this case — the next boot must retry the remainder.
+          this.logger.error(
+            `Backfilled ${backfilled}/${pending.length} credential accounts. ` +
+              `${pending.length - backfilled} user(s) CANNOT sign in until this is resolved manually. ` +
+              'The most likely cause is a duplicate (issuer, accountId) pair from an earlier partial migration.',
+          );
+          return;
+        }
+      } else {
+        this.logger.debug(`No account.${issuerField} backfill needed — no credential rows predate better-auth 1.7.`);
+      }
+
+      // Only a complete run earns the marker.
+      await markers.updateOne(
+        { _id: ACCOUNT_ISSUER_BACKFILL_ID as any },
+        { $set: { backfilled, completedAt: new Date(), issuerField, modelName } },
+        { upsert: true },
+      );
+
+      // Existence probe rather than a count: `$ne` cannot use an index, so counting to the end is a
+      // guaranteed collection scan for a log line. "At least one" is all the message needs to say.
+      const staleOther = await accounts.findOne(
+        { [issuerField]: { $exists: false }, providerId: { $ne: 'credential' } },
+        { projection: { _id: 1 } },
+      );
+
+      if (staleOther) {
+        this.logger.warn(
+          `At least one non-credential account has no "${issuerField}". better-auth >= 1.7 will not match it by ` +
+            '(issuer, accountId) — and such a sign-in does NOT simply fail: it falls back to matching the user by ' +
+            'the provider-asserted email and implicitly links a SECOND account row. If the provider-side email has ' +
+            'changed, a NEW user is created instead and the existing account is orphaned, together with the provider ' +
+            'tokens on the old row, which no unlink will ever remove. Set the issuer per provider BEFORE the first ' +
+            "social sign-in after this upgrade: the provider's real OIDC issuer, or the synthetic " +
+            '"local:oauth:<providerId>".',
+        );
+      }
+    } catch (error) {
+      // Correctness, not performance — say so loudly, but do not stop the boot:
+      // a server that starts with a warning beats one that will not start at all.
+      this.logger.error(
+        `Could not backfill the account issuer: ${error instanceof Error ? error.message : 'unknown'}. ` +
+          'Existing password users may be unable to sign in until this succeeds.',
+      );
     }
   }
 

--- a/src/core/modules/system-setup/core-system-setup.service.ts
+++ b/src/core/modules/system-setup/core-system-setup.service.ts
@@ -1,3 +1,4 @@
+import { createLocalAccountIssuer } from '@better-auth/core/db';
 import { ForbiddenException, Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
 import { InjectConnection } from '@nestjs/mongoose';
 import { isEmail } from 'class-validator';
@@ -271,11 +272,32 @@ export class CoreSystemSetupService implements OnApplicationBootstrap {
       const normalizedPassword = this.userMapper.normalizePasswordForIam(input.password);
 
       // Create user via internalAdapter (bypasses disableSignUp)
-      const iamUser = await context.internalAdapter.createUser({
-        email: input.email,
-        emailVerified: true,
-        name: input.name || input.email.split('@')[0],
-      });
+      //
+      // better-auth >= 1.7 requires a provisioning source. Without it, `createUser` throws
+      // FORBIDDEN/validation_source_missing as soon as a project configures
+      // `betterAuth.options.user.validateUserInfo`. `admin` is the honest value — the system
+      // provisions the FIRST admin, nobody signs up — and it is what better-auth's own admin
+      // plugin passes.
+      //
+      // This does NOT bypass `validateUserInfo`. The hook still runs and receives
+      // `{ method: 'admin', action: 'create-user' }`, so a project gate can still reject the
+      // initial admin; branch on `method` there if the setup should be exempt.
+      //
+      // KNOWN LIMITATION, and the reason this is spelled out: when `validateUserInfo` is
+      // configured, better-auth additionally calls `getCurrentAuthContext()`, which throws outside
+      // an endpoint context. System setup runs from `OnApplicationBootstrap` / a plain controller,
+      // never inside better-auth's request pipeline, so the call fails with
+      // FORBIDDEN/validation_context_missing and no initial admin is created. Fail-closed, but
+      // opaque. A project using that hook must provision the first admin another way — see
+      // migration-guides/11.36.x-to-11.37.0.md §7.
+      const iamUser = await context.internalAdapter.createUser(
+        {
+          email: input.email,
+          emailVerified: true,
+          name: input.name || input.email.split('@')[0],
+        },
+        { method: 'admin' },
+      );
 
       if (!iamUser) {
         throw new Error('Failed to create IAM user');
@@ -283,8 +305,14 @@ export class CoreSystemSetupService implements OnApplicationBootstrap {
 
       // Hash password and create credential account
       const hashedPassword = await context.password.hash(normalizedPassword);
+      // better-auth >= 1.7 keys accounts by (issuer, accountId) and requires the
+      // issuer. Credential accounts have no real issuer, so better-auth derives a
+      // synthetic one — always via this helper, never a hand-written literal:
+      // the format is better-auth's to change, and a copy of it would silently
+      // stop matching the accounts better-auth writes itself.
       await context.internalAdapter.linkAccount({
         accountId: iamUser.id,
+        issuer: createLocalAccountIssuer('credential'),
         password: hashedPassword,
         providerId: 'credential',
         userId: iamUser.id,

--- a/tests/regression-mutations.json
+++ b/tests/regression-mutations.json
@@ -664,6 +664,43 @@
         "tests/public-endpoint-identity.e2e-spec.ts"
       ],
       "driverSpecific": false
+    },
+    {
+      "id": "account-issuer-backfill-missing",
+      "defect": "11.37.0 — better-auth 1.7 keys an account by (issuer, accountId) and sign-in filters on it verbatim (`account.issuer === createLocalAccountIssuer('credential')`). Every credential row written by 1.6 has no `issuer` field at all, so the comparison can never hold: the upgrade itself locked out EVERY existing password user, with a bare 401 and nothing in the log explaining it. The boot-time backfill closes that gap on the first start after the upgrade. Removing the call restores the lockout.",
+      "file": "src/core/modules/better-auth/core-better-auth.service.ts",
+      "after": "  async onModuleInit(): Promise<void> {",
+      "find": "    await this.backfillAccountIssuers();",
+      "replace": "",
+      "specs": [
+        "tests/unit/better-auth-account-issuer-backfill.spec.ts",
+        "tests/stories/better-auth-issuer-upgrade.e2e-spec.ts"
+      ],
+      "driverSpecific": false
+    },
+    {
+      "id": "account-issuer-missing-on-migrate",
+      "defect": "11.37.0 — the legacy->IAM account migration wrote the credential account WITHOUT an `issuer`, so better-auth 1.7 could not find the row it had just created. The very sign-in that triggered the migration answered 401, and every later sign-in did too. Dropping the field restores that.",
+      "file": "src/core/modules/better-auth/core-better-auth-user.mapper.ts",
+      "after": "      await accountsCollection.insertOne({",
+      "find": "        issuer: createLocalAccountIssuer('credential'),\n",
+      "replace": "",
+      "specs": [
+        "tests/stories/bidirectional-auth-sync.e2e-spec.ts"
+      ],
+      "driverSpecific": false
+    },
+    {
+      "id": "account-issuer-missing-on-link-account",
+      "defect": "11.37.0 — system setup linked the initial admin's credential account WITHOUT an `issuer`, so better-auth 1.7 could not resolve it. A fresh deployment created an admin who could never sign in — the one account that must work on a new installation.",
+      "file": "src/core/modules/system-setup/core-system-setup.service.ts",
+      "after": "      await context.internalAdapter.linkAccount({",
+      "find": "        issuer: createLocalAccountIssuer('credential'),\n",
+      "replace": "",
+      "specs": [
+        "tests/stories/system-setup.e2e-spec.ts"
+      ],
+      "driverSpecific": false
     }
   ]
 }

--- a/tests/stories/better-auth-issuer-upgrade.e2e-spec.ts
+++ b/tests/stories/better-auth-issuer-upgrade.e2e-spec.ts
@@ -1,0 +1,243 @@
+/**
+ * Story: upgrading a database written by better-auth 1.6 to 1.7
+ *
+ * As an operator upgrading @lenne.tech/nest-server to 11.37.0,
+ * I want every existing password user to keep signing in,
+ * So that the upgrade itself does not lock out my entire user base.
+ *
+ * WHY THIS SUITE EXISTS, AND WHY IT CANNOT BE A UNIT TEST.
+ * From better-auth 1.7 an account is keyed by (issuer, accountId) and the sign-in route filters on
+ * it verbatim. A credential row written by 1.6 has no `issuer` field at all, so the row is simply
+ * not found and the user gets a bare 401. The boot-time backfill in `CoreBetterAuthService` repairs
+ * those rows.
+ *
+ * Every other suite in this repo creates its users through better-auth 1.7, so they always carry
+ * the field — the failure is structurally invisible to them. The unit spec
+ * (`tests/unit/better-auth-account-issuer-backfill.spec.ts`) drives a collection double, so it can
+ * prove the query shapes and the marker, but not that better-auth accepts the repaired row. Only a
+ * real database plus better-auth's own sign-in route can show that, which is what this suite does:
+ * it takes a genuine 1.7 account and strips the field back to its 1.6 shape.
+ *
+ * The load-bearing step is the FAILING sign-in in the middle. Without it, the final assertion would
+ * pass just as happily if better-auth had never filtered on the issuer at all — the test would
+ * prove the backfill writes a field, not that the field is what makes sign-in work. That step pins
+ * the upstream behaviour the entire release is predicated on: if better-auth ever relaxes the
+ * filter, this suite tells us the backfill has become unnecessary.
+ *
+ * @regression   11.37.0 — upgrading better-auth 1.6 -> 1.7 locked out every existing password user,
+ *   because their `account` rows predate the (issuer, accountId) key and sign-in filters on it.
+ * @seen-failing Remove the `await this.backfillAccountIssuers();` call from `onModuleInit()` in
+ *   src/core/modules/better-auth/core-better-auth.service.ts — registered as mutation
+ *   `account-issuer-backfill-missing` in tests/regression-mutations.json.
+ *
+ * The two account WRITE sites carry their own evidence, pinned by the suites that already cover
+ * them rather than by this one: see tests/stories/bidirectional-auth-sync.e2e-spec.ts and
+ * tests/stories/system-setup.e2e-spec.ts.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { PubSub } from 'graphql-subscriptions';
+import { Db, MongoClient } from 'mongodb';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { CoreBetterAuthService, HttpExceptionLogFilter, TestHelper } from '../../src';
+import {
+  ACCOUNT_ISSUER_BACKFILL_ID,
+  BACKFILL_MARKER_COLLECTION,
+} from '../../src/core/modules/better-auth/core-better-auth.constants';
+import envConfig from '../../src/config.env';
+import { ServerModule } from '../../src/server/server.module';
+
+/** The value better-auth derives for credential accounts. Hardcoded on purpose: if better-auth ever
+ *  changes the format, this suite must fail rather than follow it silently. */
+const CREDENTIAL_ISSUER = 'local:credential';
+
+describe('Story: better-auth 1.6 -> 1.7 issuer upgrade', () => {
+  let app;
+  let testHelper: TestHelper;
+  let mongoClient: MongoClient;
+  let db: Db;
+  let betterAuthService: CoreBetterAuthService;
+  let isBetterAuthEnabled: boolean;
+
+  const testEmails: string[] = [];
+  const testIamUserIds: string[] = [];
+
+  const generateTestEmail = (prefix: string): string => {
+    const email = `issuer-${prefix}-${Date.now()}-${Math.random().toString(36).substring(2, 8)}@test.com`;
+    testEmails.push(email);
+    return email;
+  };
+
+  /** Runs the backfill the way a boot would, but without a marker in the way. */
+  const runBackfill = async (): Promise<void> => {
+    await db.collection(BACKFILL_MARKER_COLLECTION).deleteOne({ _id: ACCOUNT_ISSUER_BACKFILL_ID as any });
+    await (betterAuthService as any).backfillAccountIssuers();
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [ServerModule],
+      providers: [{ provide: 'PUB_SUB', useValue: new PubSub() }],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalFilters(new HttpExceptionLogFilter());
+    app.setBaseViewsDir(envConfig.templates.path);
+    app.setViewEngine(envConfig.templates.engine);
+    await app.init();
+    testHelper = new TestHelper(app);
+
+    betterAuthService = moduleFixture.get(CoreBetterAuthService);
+    isBetterAuthEnabled = betterAuthService.isEnabled();
+
+    mongoClient = await MongoClient.connect(envConfig.mongoose.uri);
+    db = mongoClient.db();
+  });
+
+  afterAll(async () => {
+    if (db) {
+      for (const email of testEmails) {
+        const user = await db.collection('users').findOne({ email });
+        if (user) {
+          const userIds: any[] = [user._id, user._id.toString()];
+          if (user.iamId) userIds.push(user.iamId);
+          await db.collection('users').deleteOne({ _id: user._id });
+          await db.collection('account').deleteMany({ userId: { $in: userIds } });
+          await db.collection('session').deleteMany({ userId: { $in: userIds } });
+        }
+      }
+      for (const iamId of testIamUserIds) {
+        await db.collection('users').deleteOne({ id: iamId });
+        await db.collection('account').deleteMany({ userId: iamId });
+        await db.collection('session').deleteMany({ userId: iamId });
+      }
+    }
+
+    if (mongoClient) {
+      await mongoClient.close();
+    }
+
+    if (app) {
+      await app.close();
+    }
+  });
+
+  it('restores sign-in for a credential account written before better-auth 1.7', async () => {
+    if (!isBetterAuthEnabled) {
+      console.warn('Better-Auth is disabled — skipping');
+      return;
+    }
+
+    const email = generateTestEmail('legacy-row');
+    const password = 'IssuerUpgrade123!';
+
+    // 1. A genuine 1.7 account.
+    const signUp = await testHelper.rest('/iam/sign-up/email', {
+      method: 'POST',
+      payload: { email, name: 'Issuer Upgrade', password, termsAndPrivacyAccepted: true },
+      statusCode: 201,
+    });
+    expect(signUp.user?.id).toBeDefined();
+    testIamUserIds.push(signUp.user.id);
+
+    // better-auth stores `userId` as an ObjectId but returns a string id, so filter on `accountId` —
+    // which is a string and is the half of better-auth's own (issuer, accountId) key.
+    const accountFilter = { accountId: signUp.user.id, providerId: 'credential' };
+    expect(await db.collection('account').findOne(accountFilter)).toMatchObject({ issuer: CREDENTIAL_ISSUER });
+
+    // 2. Strip it back to the shape better-auth 1.6 wrote.
+    const stripped = await db.collection('account').updateOne(accountFilter, { $unset: { issuer: '' } });
+    expect(stripped.modifiedCount).toBe(1);
+
+    // 3. THE LOAD-BEARING STEP: sign-in must now fail. This is what proves the field is the reason
+    //    sign-in works, rather than the backfill merely writing something harmless.
+    const brokenSignIn = await testHelper.rest('/iam/sign-in/email', {
+      method: 'POST',
+      payload: { email, password },
+      statusCode: 401,
+    });
+    expect(brokenSignIn?.success).not.toBe(true);
+
+    // 4. The upgrade boot.
+    await runBackfill();
+
+    // 5. The row is repaired...
+    expect(await db.collection('account').findOne(accountFilter)).toMatchObject({ issuer: CREDENTIAL_ISSUER });
+
+    // ...and better-auth accepts it again.
+    const repairedSignIn = await testHelper.rest('/iam/sign-in/email', {
+      method: 'POST',
+      payload: { email, password },
+    });
+    expect(repairedSignIn.success).toBe(true);
+    expect(repairedSignIn.user.email).toBe(email);
+  });
+
+  it('leaves a non-credential account untouched and records the completion marker', async () => {
+    if (!isBetterAuthEnabled) {
+      console.warn('Better-Auth is disabled — skipping');
+      return;
+    }
+
+    const email = generateTestEmail('oauth-row');
+    const signUp = await testHelper.rest('/iam/sign-up/email', {
+      method: 'POST',
+      payload: { email, name: 'Oauth Shape', password: 'IssuerUpgrade123!', termsAndPrivacyAccepted: true },
+      statusCode: 201,
+    });
+    testIamUserIds.push(signUp.user.id);
+
+    // A social row from a 1.6 database: no issuer, and a provider whose issuer we cannot derive.
+    const oauthRow = {
+      accountId: `google-${signUp.user.id}`,
+      createdAt: new Date(),
+      providerId: 'google',
+      updatedAt: new Date(),
+      userId: signUp.user.id,
+    };
+    await db.collection('account').insertOne(oauthRow as any);
+
+    await runBackfill();
+
+    // Guessing an OAuth issuer would not fail loudly — it would create a second account on the
+    // user's next social sign-in. So the row stays exactly as it was.
+    const after = await db.collection('account').findOne({ accountId: oauthRow.accountId });
+    expect(after).toBeTruthy();
+    expect(after!.issuer).toBeUndefined();
+
+    // A completed run records its marker, which is what keeps every later boot from re-scanning.
+    const marker = await db.collection(BACKFILL_MARKER_COLLECTION).findOne({ _id: ACCOUNT_ISSUER_BACKFILL_ID as any });
+    expect(marker).toBeTruthy();
+
+    await db.collection('account').deleteOne({ accountId: oauthRow.accountId });
+  });
+
+  it('is idempotent — a second run changes nothing', async () => {
+    if (!isBetterAuthEnabled) {
+      console.warn('Better-Auth is disabled — skipping');
+      return;
+    }
+
+    const email = generateTestEmail('idempotent');
+    const signUp = await testHelper.rest('/iam/sign-up/email', {
+      method: 'POST',
+      payload: { email, name: 'Idempotent', password: 'IssuerUpgrade123!', termsAndPrivacyAccepted: true },
+      statusCode: 201,
+    });
+    testIamUserIds.push(signUp.user.id);
+
+    // better-auth stores `userId` as an ObjectId but returns a string id, so filter on `accountId` —
+    // which is a string and is the half of better-auth's own (issuer, accountId) key.
+    const accountFilter = { accountId: signUp.user.id, providerId: 'credential' };
+
+    await runBackfill();
+    const first = await db.collection('account').findOne(accountFilter);
+
+    await runBackfill();
+    const second = await db.collection('account').findOne(accountFilter);
+
+    expect(second!.issuer).toBe(CREDENTIAL_ISSUER);
+    expect(second!.updatedAt).toEqual(first!.updatedAt);
+  });
+});

--- a/tests/stories/bidirectional-auth-sync.e2e-spec.ts
+++ b/tests/stories/bidirectional-auth-sync.e2e-spec.ts
@@ -19,6 +19,16 @@
  *
  * Prerequisites:
  * - Better-Auth must be enabled for these tests to run
+ *
+ * @regression   11.37.0 — the legacy->IAM account migration wrote the credential account WITHOUT
+ *   an `issuer`. better-auth 1.7 keys accounts by (issuer, accountId), so it could not find the
+ *   row it had just created: the very sign-in that triggered the migration answered 401, and so
+ *   did every later one. The repeated-sign-in scenarios below are what catch it — a single
+ *   sign-in passes, because the migration itself succeeds.
+ * @seen-failing Drop the `issuer: createLocalAccountIssuer('credential'),` line from the
+ *   `insertOne` in `migrateAccountToIam()` in
+ *   src/core/modules/better-auth/core-better-auth-user.mapper.ts — registered as mutation
+ *   `account-issuer-missing-on-migrate` in tests/regression-mutations.json (7 cases go red).
  */
 
 import { Test, TestingModule } from '@nestjs/testing';

--- a/tests/stories/system-setup.e2e-spec.ts
+++ b/tests/stories/system-setup.e2e-spec.ts
@@ -19,6 +19,16 @@
  * ISOLATION: This test uses separate temporary MongoDB databases because it
  * requires zero users to test the "fresh deployment" scenario. Using the shared
  * e2e database would interfere with tests running in parallel.
+ *
+ * @regression   11.37.0 — system setup linked the initial admin's credential account WITHOUT an
+ *   `issuer`. better-auth 1.7 keys accounts by (issuer, accountId), so the account could not be
+ *   resolved: a fresh deployment produced an admin who could never sign in — the one account that
+ *   has to work on a new installation. The "can sign in via BetterAuth" cases below are what catch
+ *   it; creating the admin still succeeds, so every other assertion stays green.
+ * @seen-failing Drop the `issuer: createLocalAccountIssuer('credential'),` line from the
+ *   `linkAccount` call in src/core/modules/system-setup/core-system-setup.service.ts —
+ *   registered as mutation `account-issuer-missing-on-link-account` in
+ *   tests/regression-mutations.json (2 cases go red).
  */
 
 import { Module } from '@nestjs/common';

--- a/tests/unit/better-auth-account-issuer-backfill.spec.ts
+++ b/tests/unit/better-auth-account-issuer-backfill.spec.ts
@@ -1,0 +1,252 @@
+/**
+ * Unit Tests: the `account.issuer` backfill that keeps an upgrade to better-auth 1.7 from
+ * locking every existing password user out.
+ *
+ * WHY THIS EXISTS.
+ * Up to better-auth 1.6 a credential account was identified by `providerId` + `userId`. From
+ * 1.7 an account is keyed by (issuer, accountId), and the sign-in route filters on it verbatim:
+ *
+ *   account.providerId === 'credential' && account.issuer === credentialIssuer && ...
+ *
+ * A row written by 1.6 has no `issuer` field at all, so `undefined === 'local:credential'` is
+ * false and the account is simply not found. The user gets a 401 — not "wrong password", not a
+ * migration hint, just a failed login — and nothing in the server log explains it. That failure
+ * is invisible in this repo: our own suites create their users through 1.7, so they always carry
+ * the field. Only a database written by an older version reproduces it, which is exactly what
+ * these tests fake.
+ *
+ * The end-to-end property (a 1.6-shaped row can sign in after the upgrade) cannot be shown here,
+ * because the collection is a double — it lives in
+ * `tests/stories/better-auth-issuer-upgrade.e2e-spec.ts`, against a real database and better-auth's
+ * own sign-in route. These tests cover the query shapes, the completion marker and the failure
+ * modes around them.
+ *
+ * WHY IT IS SCOPED TO CREDENTIAL ACCOUNTS.
+ * `local:credential` is derivable — it is a pure function of the provider id. An OAuth account's
+ * issuer is not: it is either the provider's real OIDC issuer or the synthetic
+ * `local:oauth:<providerId>` fallback, decided per provider. Guessing there would not fail
+ * loudly; it would write a key that looks valid and silently produce a SECOND account on the
+ * next social sign-in. So those rows are reported and never rewritten — one test pins that
+ * boundary, because "we backfill accounts" is exactly the kind of summary that invites someone to
+ * widen the filter later.
+ *
+ * @regression   11.37.0 — better-auth 1.7 keys accounts by (issuer, accountId) and filters on it
+ *   verbatim at sign-in. Every credential row written by 1.6 lacks the field, so the upgrade
+ *   itself locked out every existing password user with a bare 401 and no log line.
+ * @seen-failing Remove the `await this.backfillAccountIssuers();` call from `onModuleInit()` in
+ *   src/core/modules/better-auth/core-better-auth.service.ts — registered as mutation
+ *   `account-issuer-backfill-missing` in tests/regression-mutations.json.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  ACCOUNT_ISSUER_BACKFILL_ID,
+  BACKFILL_MARKER_COLLECTION,
+} from '../../src/core/modules/better-auth/core-better-auth.constants';
+import { CoreBetterAuthService } from '../../src/core/modules/better-auth/core-better-auth.service';
+
+/** The value better-auth derives for credential accounts (`local:` + encoded provider id). */
+const CREDENTIAL_ISSUER = 'local:credential';
+
+interface BuildOptions {
+  /** Rows still missing the issuer, as returned by the pending lookup. */
+  pending?: { _id: string }[];
+  /** How many of those the bulk write actually modified — lower than `pending` means a partial failure. */
+  modifiedCount?: number;
+  /** A marker document, i.e. the backfill already completed on an earlier boot. */
+  markerExists?: boolean;
+  /** A non-credential row still missing the issuer, which must be reported but never written. */
+  staleOther?: boolean;
+  /** better-auth instance options, for the renamed-schema case. */
+  accountOptions?: Record<string, unknown>;
+  /** Passed verbatim as the injected better-auth instance; `null` disables the service. */
+  authInstance?: unknown;
+  /** Config object; `{ enabled: false }` disables the service with an instance present. */
+  config?: Record<string, unknown>;
+  /** Omit the database entirely (GraphQL-only / DB-less boot). */
+  withoutDb?: boolean;
+}
+
+function buildService(options: BuildOptions = {}) {
+  const pending = options.pending ?? [];
+
+  const bulkWrite = vi.fn().mockResolvedValue({ modifiedCount: options.modifiedCount ?? pending.length });
+  const toArray = vi.fn().mockResolvedValue(pending);
+  const find = vi.fn().mockReturnValue({ toArray });
+  const accountFindOne = vi.fn().mockResolvedValue(options.staleOther ? { _id: 'oauth-row' } : null);
+  const createIndex = vi.fn().mockResolvedValue('ok');
+
+  const markerFindOne = vi.fn().mockResolvedValue(options.markerExists ? { _id: ACCOUNT_ISSUER_BACKFILL_ID } : null);
+  const markerUpdateOne = vi.fn().mockResolvedValue({ upsertedCount: 1 });
+
+  const accountCollection = { bulkWrite, createIndex, find, findOne: accountFindOne };
+  const markerCollection = { createIndex, findOne: markerFindOne, updateOne: markerUpdateOne };
+
+  const collection = vi.fn((name: string) =>
+    name === BACKFILL_MARKER_COLLECTION ? markerCollection : accountCollection,
+  );
+
+  const connection = options.withoutDb ? {} : { db: { collection } };
+
+  const authInstance =
+    'authInstance' in options ? options.authInstance : { options: { account: options.accountOptions } };
+
+  const service = new CoreBetterAuthService(
+    authInstance as never,
+    connection as never,
+    (options.config ?? { enabled: true }) as never,
+  );
+
+  const logger = {
+    debug: vi.spyOn((service as any).logger, 'debug').mockImplementation(() => undefined),
+    error: vi.spyOn((service as any).logger, 'error').mockImplementation(() => undefined),
+    log: vi.spyOn((service as any).logger, 'log').mockImplementation(() => undefined),
+    warn: vi.spyOn((service as any).logger, 'warn').mockImplementation(() => undefined),
+  };
+
+  return { accountFindOne, bulkWrite, collection, find, logger, markerFindOne, markerUpdateOne, service };
+}
+
+describe('better-auth account.issuer backfill', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sets the credential issuer on rows that predate better-auth 1.7', async () => {
+    const { bulkWrite, find, logger, service } = buildService({ pending: [{ _id: 'a' }, { _id: 'b' }, { _id: 'c' }] });
+
+    await service.onModuleInit();
+
+    // Only rows still missing the field, so a second boot is a no-op.
+    expect(find).toHaveBeenCalledWith(
+      { issuer: { $exists: false }, providerId: 'credential' },
+      { projection: { _id: 1 } },
+    );
+
+    const [ops, opts] = bulkWrite.mock.calls[0];
+    expect(ops).toHaveLength(3);
+    expect(ops[0].updateOne.update).toEqual({ $set: { issuer: CREDENTIAL_ISSUER } });
+
+    // `ordered: false` is the difference between one bad row costing itself and one bad row
+    // locking out every user after it.
+    expect(opts).toEqual({ ordered: false });
+
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('3 credential account(s)'));
+  });
+
+  it('never rewrites accounts that already carry an issuer', async () => {
+    const { find, service } = buildService({ pending: [{ _id: 'a' }] });
+
+    await service.onModuleInit();
+
+    // Without `$exists: false` the update would also hit rows better-auth wrote itself —
+    // including OAuth rows whose issuer is NOT the credential one.
+    const [filter] = find.mock.calls[0];
+    expect(filter.issuer).toEqual({ $exists: false });
+  });
+
+  it('leaves non-credential accounts to the project instead of guessing their issuer', async () => {
+    const { accountFindOne, bulkWrite, logger, service } = buildService({
+      pending: [{ _id: 'a' }],
+      staleOther: true,
+    });
+
+    await service.onModuleInit();
+
+    // Reported...
+    expect(accountFindOne).toHaveBeenCalledWith(
+      { issuer: { $exists: false }, providerId: { $ne: 'credential' } },
+      { projection: { _id: 1 } },
+    );
+
+    // ...and the warning has to describe what actually happens, because an operator acts on it:
+    // better-auth does NOT simply refuse such a sign-in, it implicitly links a second row.
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('implicitly links a SECOND account row'));
+
+    // ...but never written: the only write is the credential-scoped one.
+    expect(bulkWrite).toHaveBeenCalledTimes(1);
+    expect(bulkWrite.mock.calls[0][0][0].updateOne.update).toEqual({ $set: { issuer: CREDENTIAL_ISSUER } });
+  });
+
+  it('skips the scan entirely once the completion marker exists', async () => {
+    const { bulkWrite, find, markerFindOne, service } = buildService({ markerExists: true });
+
+    await service.onModuleInit();
+
+    expect(markerFindOne).toHaveBeenCalledWith({ _id: ACCOUNT_ISSUER_BACKFILL_ID });
+
+    // The whole point of the marker: neither of the two unindexable queries runs again. Without
+    // this, every boot of every replica pays a full pass over the account collection, forever.
+    expect(find).not.toHaveBeenCalled();
+    expect(bulkWrite).not.toHaveBeenCalled();
+  });
+
+  it('writes the marker after a complete run', async () => {
+    const { markerUpdateOne, service } = buildService({ pending: [{ _id: 'a' }] });
+
+    await service.onModuleInit();
+
+    expect(markerUpdateOne).toHaveBeenCalledWith(
+      { _id: ACCOUNT_ISSUER_BACKFILL_ID },
+      { $set: expect.objectContaining({ backfilled: 1, modelName: 'account' }) },
+      { upsert: true },
+    );
+  });
+
+  it('does NOT write the marker when only some rows could be backfilled', async () => {
+    const { logger, markerUpdateOne, service } = buildService({
+      modifiedCount: 1,
+      pending: [{ _id: 'a' }, { _id: 'b' }, { _id: 'c' }],
+    });
+
+    await service.onModuleInit();
+
+    // Marking a partial run complete would strand the remaining users permanently — the next
+    // boot has to retry them.
+    expect(markerUpdateOne).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('2 user(s) CANNOT sign in'));
+  });
+
+  it('follows a renamed account model and issuer field instead of silently doing nothing', async () => {
+    const { collection, find, logger, service } = buildService({
+      accountOptions: { fields: { issuer: 'issuerUrl' }, modelName: 'accounts' },
+      pending: [{ _id: 'a' }],
+    });
+
+    await service.onModuleInit();
+
+    expect(collection).toHaveBeenCalledWith('accounts');
+    expect(find.mock.calls[0][0]).toEqual({ issuerUrl: { $exists: false }, providerId: 'credential' });
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('customised schema'));
+  });
+
+  it('does not stop the boot when the backfill itself fails, and says so loudly', async () => {
+    const { bulkWrite, logger, service } = buildService({ pending: [{ _id: 'a' }] });
+    bulkWrite.mockRejectedValue(new Error('replica set stepped down'));
+
+    // A server that starts with a loud error beats one that will not start at all — but "loud"
+    // is half the contract, so assert the log, not just the resolution.
+    await expect(service.onModuleInit()).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('replica set stepped down'));
+  });
+
+  it('stays idle when better-auth is present but disabled by config', async () => {
+    const { find, markerFindOne, service } = buildService({
+      authInstance: { options: {} },
+      config: { enabled: false },
+    });
+
+    await service.onModuleInit();
+
+    // The instance exists, so this exercises the config flag rather than the null-instance guard.
+    expect(markerFindOne).not.toHaveBeenCalled();
+    expect(find).not.toHaveBeenCalled();
+  });
+
+  it('stays idle when no database connection is available', async () => {
+    const { collection, service } = buildService({ pending: [{ _id: 'a' }], withoutDb: true });
+
+    await expect(service.onModuleInit()).resolves.toBeUndefined();
+    expect(collection).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What this is

better-auth moves to **1.7.x** and out of this package's `dependencies`. `better-auth`, `@better-auth/passkey` and the new `@better-auth/core` are now **non-optional peer dependencies**, so the consuming project owns the version — in a fullstack project the frontend talks to better-auth too, and a version owned here could silently split api and app.

## The part that would have broken every deployment

From 1.7 an account is keyed by `(issuer, accountId)`, and better-auth's sign-in path filters on it verbatim. Rows written by 1.6 carry no `issuer` at all, so the upgrade **by itself** would have locked out every existing password user — a bare 401, with nothing in the log to explain it.

- Both account write sites now set the field, derived via `createLocalAccountIssuer()`.
- A boot-time backfill repairs existing rows once, guarded by a completion marker so later boots cost a single `_id` lookup instead of two unindexable collection scans.
- OAuth/SSO rows are reported, never guessed — a wrong issuer there does not fail loudly, it silently creates a second account on the next social sign-in.

## Upgrading

Every project needs §1 of the migration guide (`pnpm add better-auth@1.7.1 @better-auth/passkey@1.7.1 @better-auth/core@1.7.1`). Projects using social or SSO logins need §4 **before** the first social sign-in after upgrading.

Full guide: [`migration-guides/11.36.x-to-11.37.0.md`](migration-guides/11.36.x-to-11.37.0.md)

## Under the hood

Three regression mutations registered and each observed red (8, 7 and 2 cases). New e2e suite proves the actual property end to end: strip a real account back to its 1.6 shape, confirm sign-in **fails**, run the backfill, confirm it succeeds again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)