### PR TITLE
11.37.0 (fix): split the account-issuer backfill evidence into two mutations

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -266,7 +266,7 @@ pnpm run check:mutations -- --id=<id>       # one mutation
 pnpm run check:mutations -- --list          # the registry, without running anything
 pnpm run check:mutations -- --allow-dirty   # when the fix and its evidence share a working tree
 pnpm run check:mutations -- --jobs=4        # N mutations at a time (default: 2, or 4 on >=12 cores)
-pnpm run check:mutations -- --no-infra      # only the 22 that need no MongoDB
+pnpm run check:mutations -- --no-infra      # only the 23 that need no MongoDB
 pnpm run check:mutations -- --since=<ref>   # only mutations touching files changed since <ref>
 ```
 
@@ -284,7 +284,7 @@ when the registry, a vitest config or a setup file changed, since those can move
 **Why the gate does not cache per-mutation verdicts instead.** It runs ONCE PER RELEASE, not per
 commit, so selective re-running would save ~10 minutes a release. The price is a cache that has to
 model each spec's full dependency closure correctly, and getting that wrong produces a stale PASS
-for a test that has since gone vacuous — exactly what the gate is there to prevent. Bad trade at 56
+for a test that has since gone vacuous — exactly what the gate is there to prevent. Bad trade at 57
 mutations. Worth revisiting around 100, where the full run approaches half an hour.
 
 Not part of `pnpm run check` — it edits source and re-runs whole e2e suites. It belongs in review
@@ -326,7 +326,7 @@ exactly the environment where the answer matters.
 
 Worth knowing before optimising the wrong thing: the specs behind all 34 e2e mutations add up to
 **~40 seconds**. The step takes ~740s. The remaining ~700s is paying vitest's startup — process
-spawn, transform, module graph, mongod connect, DB create and drop — once per mutation, 56 times.
+spawn, transform, module graph, mongod connect, DB create and drop — once per mutation, 57 times.
 That work is largely single-threaded I/O and barely scales with cores: the full registry measures
 **744s on a 12-core laptop and 777s on a 4-vCPU CI runner**.
 

--- a/scripts/check-mutations.mjs
+++ b/scripts/check-mutations.mjs
@@ -42,7 +42,7 @@
  *   pnpm run check:mutations -- --no-infra      only the mutations that need no MongoDB
  *   pnpm run check:mutations -- --since=<ref>   only mutations touching files changed since <ref>
  *
- * `--no-infra` selects the 22 mutations whose specs are all unit specs — the unit runner has no
+ * `--no-infra` selects the 23 mutations whose specs are all unit specs — the unit runner has no
  * `globalSetup`, so those need no MongoDB and no test containers. It is a CAPABILITY filter, for a
  * machine that cannot start the infrastructure; it is not a "quick mode". When you are iterating on
  * one mutation, `--id=<id>` is both faster and more relevant.
@@ -53,11 +53,11 @@
  * refactor three modules away can hollow out a test it will happily skip — which is exactly the
  * failure this tool exists to catch. Fast feedback while you work; never the evidence.
  *
- * Why the release gate still runs all 56 rather than caching per-mutation verdicts: the gate runs
+ * Why the release gate still runs all 57 rather than caching per-mutation verdicts: the gate runs
  * ONCE PER RELEASE, not per commit, so the saving is ~10 minutes a release. The price would be a
  * cache that has to model each spec's full dependency closure correctly, and the failure mode of
  * getting that wrong is a stale PASS for a test that has since gone vacuous — the precise thing the
- * gate is there to prevent. Bad trade at 56 mutations. Revisit around 100, where the full run
+ * gate is there to prevent. Bad trade at 57 mutations. Revisit around 100, where the full run
  * approaches half an hour.
  *
  * PARALLELISM

--- a/tests/regression-mutations.json
+++ b/tests/regression-mutations.json
@@ -673,8 +673,7 @@
       "find": "    await this.backfillAccountIssuers();",
       "replace": "",
       "specs": [
-        "tests/unit/better-auth-account-issuer-backfill.spec.ts",
-        "tests/stories/better-auth-issuer-upgrade.e2e-spec.ts"
+        "tests/unit/better-auth-account-issuer-backfill.spec.ts"
       ],
       "driverSpecific": false
     },
@@ -699,6 +698,18 @@
       "replace": "",
       "specs": [
         "tests/stories/system-setup.e2e-spec.ts"
+      ],
+      "driverSpecific": false
+    },
+    {
+      "id": "account-issuer-backfill-writes-nothing",
+      "defect": "11.37.0 — the boot-time backfill is what lets a credential account written by better-auth 1.6 sign in after the upgrade. Narrowing its filter so it matches no row leaves every legacy account without an `issuer`, and better-auth 1.7 cannot resolve them: the user gets a bare 401. This mutation targets the backfill's WRITE, not its wiring — the e2e suite calls the method directly, so it can only observe the former.",
+      "file": "src/core/modules/better-auth/core-better-auth.service.ts",
+      "after": "      const pending = await accounts",
+      "find": "        .find({ [issuerField]: { $exists: false }, providerId: 'credential' }, { projection: { _id: 1 } })",
+      "replace": "        .find({ [issuerField]: { $exists: false }, providerId: '__never_matches__' }, { projection: { _id: 1 } })",
+      "specs": [
+        "tests/stories/better-auth-issuer-upgrade.e2e-spec.ts"
       ],
       "driverSpecific": false
     }

--- a/tests/stories/better-auth-issuer-upgrade.e2e-spec.ts
+++ b/tests/stories/better-auth-issuer-upgrade.e2e-spec.ts
@@ -26,9 +26,15 @@
  *
  * @regression   11.37.0 — upgrading better-auth 1.6 -> 1.7 locked out every existing password user,
  *   because their `account` rows predate the (issuer, accountId) key and sign-in filters on it.
- * @seen-failing Remove the `await this.backfillAccountIssuers();` call from `onModuleInit()` in
- *   src/core/modules/better-auth/core-better-auth.service.ts — registered as mutation
- *   `account-issuer-backfill-missing` in tests/regression-mutations.json.
+ * @seen-failing Narrow the backfill's own query so it matches no row (`providerId: '__never_matches__'`)
+ *   in src/core/modules/better-auth/core-better-auth.service.ts — registered as mutation
+ *   `account-issuer-backfill-writes-nothing` in tests/regression-mutations.json.
+ *
+ *   Deliberately NOT the mutation that removes the `onModuleInit()` call: this suite invokes
+ *   `backfillAccountIssuers()` directly, so it is structurally blind to the wiring and would stay
+ *   green with that defect restored. The wiring is pinned by the unit spec instead. The two halves
+ *   need separate mutations, and a mutation whose specs span both runners silently drops the unit
+ *   half — `check-mutations.mjs` picks ONE vitest config per mutation.
  *
  * The two account WRITE sites carry their own evidence, pinned by the suites that already cover
  * them rather than by this one: see tests/stories/bidirectional-auth-sync.e2e-spec.ts and


### PR DESCRIPTION
Follow-up to #599. The publish gate caught its own blind spot before npm ever saw the package — `11.37.0` is tagged but was never published, so this lands under the same version.

## What the gate found

`account-issuer-backfill-missing` reported **"specs stayed GREEN with the defect restored — vacuous"**. Two mistakes had stacked:

1. **The mutation listed a unit spec and an e2e spec.** `check-mutations.mjs` picks *one* vitest config per mutation — unit only when every spec is a unit spec. A mixed list therefore resolves to the e2e config, and the unit spec is never matched. It silently did not run.
2. **The e2e suite calls `backfillAccountIssuers()` directly**, so removing the `onModuleInit()` call cannot make it red. It is structurally blind to the wiring.

Together: the only spec that could see the defect was not executed, and the one that ran could not see it.

## The fix

- `account-issuer-backfill-missing` is unit-only again and pins the **wiring** (the `onModuleInit()` call).
- New `account-issuer-backfill-writes-nothing` pins the **write**, by narrowing the backfill's own query so it matches no row — that is what the e2e suite can actually observe.

Both verified red in their final configuration: 8 cases for the wiring, 1 for the write.

## Worth generalising

A mutation confirmed *before* its spec list changed is no longer evidence for the list it has now. I confirmed this one, then added the e2e spec, and did not re-confirm — which is exactly the gap the gate exists to close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)