### PR TITLE
ci(publish): run the regression-evidence gate alongside the publish, not in front of it

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,16 +77,9 @@ jobs:
       - name: SWC module-graph guard (TDZ)
         run: pnpm run check:swc-tdz
 
-      # Re-runs the evidence behind every `@regression` test: applies each mutation registered in
-      # tests/regression-mutations.json and REQUIRES the specs that claim to catch it to go red.
-      #
-      # Not redundant with the test run above, which proves the suite is GREEN. Green is exactly
-      # what a vacuous test also is — and two regression tests written while fixing 11.33.1 passed
-      # with the defect fully restored. This is the only step that can tell the two apart. It
-      # belongs on the publish path rather than on every push because it edits source and re-runs
-      # whole e2e suites; a CI checkout is clean, so the working-tree guard is satisfied.
-      - name: Regression evidence (mutation check)
-        run: pnpm run check:mutations
+      # NOTE: the regression-evidence gate used to run HERE, and moved to its own parallel job
+      # (see `regression-evidence` below). It cost ~13 of this job's ~18 minutes while blocking
+      # every release behind it. It now runs alongside the publish instead of in front of it.
 
       - name: Build
         run: pnpm run build
@@ -125,6 +118,128 @@ jobs:
       # It matters on a self-hosted runner, where a leftover `ci-redis` makes the
       # NEXT job fail on a name conflict before a single test runs.
       # `if: always()` so a failed job cleans up too.
+      - name: Remove test infrastructure
+        if: always()
+        run: docker rm -f "$REDIS_CONTAINER" "$RUSTFS_CONTAINER" 2>/dev/null || true
+
+  # ---------------------------------------------------------------------------------------------
+  # Regression evidence — runs ALONGSIDE the publish, and deliberately does not block it.
+  #
+  # WHAT IT CHECKS, and why that justifies the unusual arrangement: it re-applies every mutation in
+  # tests/regression-mutations.json and REQUIRES the specs that claim to catch that defect to go
+  # red. It does not test the product — the `publish` job does that, in full, and still gates the
+  # release. This job tests the TESTS: a regression test that has gone vacuous is green, and a
+  # green test looks identical whether it checks something or nothing. Two tests written while
+  # fixing 11.33.1 passed with the defect fully restored, and 11.37.0 shipped a mutation whose
+  # spec list silently dropped the only spec that could observe it.
+  #
+  # WHY IT NO LONGER BLOCKS: it costs ~13 minutes against the publish job's ~5, so every release
+  # waited on it. What it protects is the FRESHNESS OF THE SAFETY NET, not the correctness of the
+  # artifact — a vacuous regression test does not make the published package wrong, it makes a
+  # future regression harder to catch. That is worth fixing promptly; it is not worth holding
+  # every release hostage. So the package ships on the `publish` job's own gates, and this job
+  # reports independently.
+  #
+  # HOW A FAILURE IS SEEN — three ways, none of which rely on someone watching a log:
+  #   1. The workflow run is marked failed (the publish itself has already happened).
+  #   2. A GitHub issue is opened automatically, labelled `regression-evidence`.
+  #   3. `/lt-dev:publish` checks this job's last conclusion BEFORE starting a new release and
+  #      refuses to proceed silently past a red one.
+  # Remove any of the three and this becomes a job nobody reads.
+  regression-evidence:
+    name: Regression evidence (non-blocking)
+    runs-on: ubuntu-latest
+    # No `needs:` — this is the point. It starts with the publish job, not after it.
+    strategy:
+      matrix:
+        node-version: [ 24.x ]
+        mongodb-version: [ '7.0' ]
+    env:
+      REDIS_CONTAINER: evidence-redis
+      RUSTFS_CONTAINER: evidence-rustfs
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.12.1
+        with:
+          mongodb-version: ${{ matrix.mongodb-version }}
+
+      # Own container names: this job runs CONCURRENTLY with `publish`, and on a self-hosted
+      # runner the two would otherwise collide on `ci-redis` / `ci-rustfs`.
+      - name: Start test infrastructure (Redis + S3)
+        uses: ./.github/actions/test-infra
+        with:
+          redis-name: ${{ env.REDIS_CONTAINER }}
+          rustfs-name: ${{ env.RUSTFS_CONTAINER }}
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Regression evidence (mutation check)
+        id: evidence
+        run: pnpm run check:mutations
+
+      # Opens an issue when the gate goes red. Without this, a red run is only noticed at the NEXT
+      # release — which may be weeks away, and the whole point is that nobody has to watch.
+      # `if: failure()` covers a crashed run too, which is itself a finding: an INCONCLUSIVE gate
+      # proves nothing about the evidence.
+      - name: Open an issue on failure
+        if: failure()
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const run = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const release = context.payload.release?.tag_name ?? context.sha.slice(0, 8);
+            const title = `Regression evidence failed for ${release}`;
+            const body = [
+              `The regression-evidence gate failed while publishing **${release}**.`,
+              '',
+              `**The package was published** — this job does not block the release. What failed is the`,
+              'evidence behind the regression tests, not the product: one or more mutations no longer',
+              'turn their specs red, which means those tests may be checking nothing.',
+              '',
+              `Run: ${run}`,
+              '',
+              '### What to do',
+              '',
+              '1. Read which mutation failed. `FAIL … stayed GREEN` means a vacuous test;',
+              '   `INCONCLUSIVE` means the run crashed and proved nothing either way.',
+              '2. Reproduce locally: `pnpm run check:mutations -- --id=<mutation-id>`',
+              '3. Either repair the test so it observes the defect again, or re-point the mutation if',
+              '   the defect is no longer reachable. Both are real outcomes; silently deleting the',
+              '   mutation is not.',
+              '',
+              'This issue is opened automatically. `/lt-dev:publish` also refuses to start a new release',
+              'while the last run of this job is red, so it cannot be missed on the next release either.',
+            ].join('\n');
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'regression-evidence',
+            });
+            if (existing.data.some((issue) => issue.title === title)) return;
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['regression-evidence'],
+            });
+
       - name: Remove test infrastructure
         if: always()
         run: docker rm -f "$REDIS_CONTAINER" "$RUSTFS_CONTAINER" 2>/dev/null || true

--- a/scripts/check-mutations.mjs
+++ b/scripts/check-mutations.mjs
@@ -189,8 +189,36 @@ function specEnv(specs, jobs) {
   };
 }
 
-function specConfig(specs) {
-  return specs.every((spec) => spec.startsWith('tests/unit/')) ? 'vitest.config.ts' : 'vitest-e2e.config.ts';
+/**
+ * Pick the ONE vitest config a mutation's specs run under.
+ *
+ * The two runners have DISJOINT globs — `vitest.config.ts` claims `tests/unit/**`, the e2e config
+ * claims `tests/**\/*.e2e-spec.ts` and `tests/stories/**\/*.story.test.ts`. A spec that the chosen
+ * config does not match is not an error there: vitest simply runs the ones it recognises. So a
+ * mixed list used to resolve to the e2e config and DROP the unit specs in silence — the mutation
+ * then reported "specs stayed GREEN", i.e. vacuous, for specs that had never executed.
+ *
+ * That happened in 11.37.0, and the failure is worse than a wrong verdict: the dropped spec was
+ * the only one that could observe the defect, so the registry claimed evidence it did not have.
+ * Refusing the configuration makes the mode unreachable instead of merely avoided this once — a
+ * mutation needs its specs on ONE side of the split, and a defect that needs both is two
+ * mutations, because the two halves are genuinely different claims.
+ */
+function specConfig(specs, id) {
+  const unit = specs.filter((spec) => spec.startsWith('tests/unit/'));
+
+  if (unit.length && unit.length !== specs.length) {
+    const e2e = specs.filter((spec) => !spec.startsWith('tests/unit/'));
+    throw new Error(
+      `mutation '${id ?? '(unknown)'}' mixes unit and e2e specs, which cannot run under one vitest config:\n` +
+        `  unit: ${unit.join(', ')}\n` +
+        `  e2e : ${e2e.join(', ')}\n` +
+        'Split it into one mutation per runner. Each half is its own claim about the defect, and a\n' +
+        'mixed list would silently drop one of them and report the survivors as the whole story.',
+    );
+  }
+
+  return unit.length === specs.length ? 'vitest.config.ts' : 'vitest-e2e.config.ts';
 }
 
 /**
@@ -200,13 +228,13 @@ function specConfig(specs) {
  * `Promise.all` over several of them executes strictly one after another. The parallel path would
  * have looked parallel, taken exactly as long as the sequential one, and nothing would have said so.
  */
-function runSpecs(specs, cwd = ROOT, jobs = 1) {
+function runSpecs(specs, cwd = ROOT, jobs = 1, id = undefined) {
   return new Promise((resolveRun) => {
     // `node_modules/.bin/vitest`, not `npx`: measured 0.04s vs 0.24s per spawn, and this runs once
     // per mutation.
     const child = spawn(
       join(ROOT, 'node_modules', '.bin', 'vitest'),
-      ['run', '--config', specConfig(specs), ...specs],
+      ['run', '--config', specConfig(specs, id), ...specs],
       {
         cwd,
         env: specEnv(specs, jobs),
@@ -667,7 +695,7 @@ async function runOne(mutation, cwd, jobs, live) {
     writeFileSync(file, mutated);
     applied = true;
     emit(`   applied, running ${mutation.specs.join(' ')}\n`);
-    const { code, output } = await runSpecs(mutation.specs, cwd, jobs);
+    const { code, output } = await runSpecs(mutation.specs, cwd, jobs, mutation.id);
     const verdict = classifyRun({ code, output });
     emit(`   ${verdict.label}\n`);
     // A failing verdict without its reason is what made the 11.36.3 CI failure undiagnosable.

--- a/tests/unit/regression-evidence.spec.ts
+++ b/tests/unit/regression-evidence.spec.ts
@@ -131,6 +131,32 @@ describe('regression-test evidence', () => {
     });
   });
 
+  describe('every mutation runs under exactly one vitest runner', () => {
+    // `check-mutations.mjs` spawns ONE vitest per mutation, and the two runners have disjoint
+    // globs. A spec the chosen config does not match is not an error there — vitest just runs the
+    // ones it recognises — so a mixed list silently drops half the specs and then reports the
+    // survivors as the whole story. In 11.37.0 the dropped half was the only spec that could
+    // observe the defect, and the mutation was reported as vacuous evidence.
+    //
+    // The script refuses such a list at runtime; this asserts it structurally, so the registry
+    // cannot reach that state in the first place — a mutation is only checked by the script when
+    // somebody runs the (release-path) gate, while this runs on every `check`.
+    it.each(registry.mutations.map(mutation => [mutation.id, mutation] as const))(
+      '%s does not mix unit and e2e specs',
+      (_id, mutation) => {
+        const unit = mutation.specs.filter(spec => spec.startsWith('tests/unit/'));
+        const e2e = mutation.specs.filter(spec => !spec.startsWith('tests/unit/'));
+
+        expect(
+          unit.length === 0 || e2e.length === 0,
+          `mutation '${mutation.id}' spans both runners (unit: ${unit.join(', ') || 'none'} | `
+            + `e2e: ${e2e.join(', ') || 'none'}). Split it — each half is its own claim about the `
+            + 'defect, and one vitest run cannot execute both.',
+        ).toBe(true);
+      },
+    );
+  });
+
   describe('the registry cannot rot into a no-op', () => {
     it.each(registry.mutations.map(mutation => [mutation.id, mutation] as const))(
       '%s still matches its target exactly once',


### PR DESCRIPTION
Cuts the publish workflow from ~18 minutes to ~5 by removing the regression-evidence gate from the critical path — without giving up the gate.

## What changed

`publish.yml` now has two jobs with **no dependency between them**:

| Job | Blocks the release? | What it proves |
|---|---|---|
| `publish` | yes | the artifact — audit, full suite, TDZ guard, build, consumer gate, npm |
| `regression-evidence` | **no** | that the 57 registered regression tests still observe their defects |

## Why this trade is defensible

The gate does not test the product. The full suite still gates the release, unchanged. It tests the **tests**: whether a regression test has gone vacuous. That does not make the published package wrong — it makes a *future* regression harder to catch. Worth fixing promptly, rarely worth holding every release hostage.

## Why it is still safe

A red run cannot be missed, and that takes all three:

1. the workflow run is marked failed (the publish has already happened by then),
2. an issue labelled `regression-evidence` is opened automatically, with the reproduction command,
3. `/lt-dev:publish` reads the last conclusion in its preflight — shipped in lt-dev 8.8.2.

Remove any one and this becomes a job nobody reads, which is **strictly worse than blocking** because it still looks like a safety net. That is written into the workflow comment and into the `maintaining-lt-stack` skill, for whoever makes the next gate non-blocking.

## Also: the hole that made 11.37.0's first publish fail

`check-mutations.mjs` picks *one* vitest config per mutation, and the two runners have disjoint globs — so a spec list spanning both silently dropped half of it and reported the survivors as the whole story. That is how a mutation reported "specs stayed GREEN — vacuous".

- `specConfig()` now **refuses** such a list instead of resolving it.
- `regression-evidence.spec.ts` asserts the same invariant **structurally**, so it runs on every `check` rather than only at release time. The registry cannot reach that state any more.

Both verified by restoring the forbidden configuration on purpose: the unit guard fails with `spans both runners`, the script aborts with `mixes unit and e2e specs`.

## Release impact

None. Nothing here reaches the npm tarball (`files` covers `dist`, `src`, `bin` and the docs), so this rides along with the next real release instead of minting one.

Check green: 3700 tests / 173 files, audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)